### PR TITLE
refactor(supabase): remove redundant client-side auth checks

### DIFF
--- a/src/lib/supabase/tables/service_logs.ts
+++ b/src/lib/supabase/tables/service_logs.ts
@@ -1,4 +1,3 @@
-import { browserAuthClient } from '@/dependency/auth-client/browser';
 import { browserDatabaseClient } from '@/dependency/database-client/browser';
 import { toSafeNumber } from '@/lib/utils';
 import type { ServiceLog } from '@/types';
@@ -58,13 +57,6 @@ export async function getServiceLogsWithCostByCarId(
 }
 
 export async function deleteServiceLogById(id: string) {
-  const sessionResult = await browserAuthClient.authenticate();
-
-  if (!sessionResult.success) {
-    const { message } = sessionResult.error;
-    throw new Error(message);
-  }
-
   const queryResult = await browserDatabaseClient.query(async (from) =>
     from('service_logs').delete().eq('id', id).select('id').single(),
   );

--- a/src/module/car/service-log/ui/forms/add/use-add.ts
+++ b/src/module/car/service-log/ui/forms/add/use-add.ts
@@ -1,18 +1,17 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { Route } from 'next';
-import { useEffect, useState } from 'react';
 
 import type { ServiceLogPostRouteHandlerRequest } from '@/app/api/service-log/route';
 import type { CarServiceLogFormValues } from '@/car/schemas/zod/carServiceLogFormSchema';
 import { useToasts } from '@/common/presentation/hook/use-toasts';
-import { browserAuthClient } from '@/dependency/auth-client/browser';
 import { httpClient } from '@/dependency/http-client';
 import { queryKeys } from '@/lib/tanstack/keys';
 import {
   serviceLogsByCarIdAddOnError,
   serviceLogsByCarIdAddOnMutate,
 } from '@/lib/tanstack/service_logs';
+import { useSessionUser } from '@/user/presentation/hooks/use-session-user';
 
 import type { AddFormProps } from './add';
 
@@ -51,7 +50,8 @@ export function useAddForm({
   carId,
   onSubmit,
 }: Pick<AddFormProps, 'carId' | 'onSubmit'>) {
-  const [userId, setUserId] = useState<string | undefined>(undefined);
+  const { data: sessionUser } = useSessionUser();
+  const userId = sessionUser?.id;
 
   const { addToast } = useToasts();
 
@@ -69,23 +69,6 @@ export function useAddForm({
       addToast(error.message, 'error');
     },
   });
-
-  useEffect(() => {
-    const getUserId = async () => {
-      const sessionResult = await browserAuthClient.authenticate();
-
-      if (!sessionResult.success) {
-        setUserId(undefined);
-        return;
-      }
-
-      const authIdentity = sessionResult.data;
-
-      setUserId(authIdentity.id);
-    };
-
-    getUserId();
-  }, []);
 
   const handleFormSubmit = async (formData: CarServiceLogFormValues) => {
     mutate(

--- a/src/module/user/infrastructure/tanstack/mutation-options/avatar-change.ts
+++ b/src/module/user/infrastructure/tanstack/mutation-options/avatar-change.ts
@@ -1,7 +1,6 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { mutationOptions } from '@tanstack/react-query';
 
-import { browserAuthClient } from '@/dependency/auth-client/browser';
 import { browserStorageClient } from '@/dependency/storage-client/browser';
 import { hashFile } from '@/lib/utils';
 import type { UserDto } from '@/user/application/dto/user';
@@ -20,18 +19,17 @@ export const userAvatarChangeMutationOptions = (queryClient: QueryClient) =>
 
       if (!image) throw new Error('No file was provided. Try again.');
 
-      const sessionResult = await browserAuthClient.authenticate();
+      const sessionUser = queryClient.getQueryData<UserDto>(
+        queryKeys.sessionUser,
+      );
 
-      if (!sessionResult.success) {
-        const { message } = sessionResult.error;
-        throw new Error(message);
+      if (!sessionUser) {
+        throw new Error('You must be signed in to change your avatar.');
       }
-
-      const authIdentity = sessionResult.data;
 
       const hashedFile = await hashFile(image);
 
-      const uploadPath = `${authIdentity.id}/${hashedFile}`;
+      const uploadPath = `${sessionUser.id}/${hashedFile}`;
 
       const uploadResult = await browserStorageClient.upload(
         'avatars',


### PR DESCRIPTION
RLS policies already enforce authorization at the database/storage layer, so re-authenticating with browserAuthClient.authenticate() client-side before mutations was redundant and inconsistent across call sites.

- deleteServiceLogById: drop the auth check, matching deleteCar and other mutations that rely on RLS alone.
- use-add.ts: source the session user id from useSessionUser() instead of a manual useEffect + authenticate() call, matching other hooks.
- avatar-change.ts: read the session user from the already-cached sessionUser query data via queryClient.getQueryData instead of a fresh authenticate() round-trip. Storage RLS already restricts writes to the caller's own uid-prefixed path regardless of what id the client supplies.