### PR TITLE
fix(api): validate response body success

### DIFF
--- a/src/common/interface/api/response.ts
+++ b/src/common/interface/api/response.ts
@@ -14,7 +14,11 @@ type ApiResponseFailureResult<E extends ApiResponseError> = FailureResult<
   ApiResponseMeta
 >;
 
-export type ApiResponseSuccessResult<T> = SuccessResult<T, ApiResponseMeta>;
+type ApiResponseSuccessResult<T> = SuccessResult<T, ApiResponseMeta>;
+
+export type ApiResponseBody<T, E extends ApiResponseError = ApiResponseError> =
+  | ApiResponseSuccessResult<T>
+  | ApiResponseFailureResult<E>;
 
 export type ApiResponse<T, E extends ApiResponseError> = Promise<
   | ReturnType<typeof successApiResponse<T> | typeof redirectApiResponse>

--- a/src/module/car/service-log/ui/forms/add/use-add.ts
+++ b/src/module/car/service-log/ui/forms/add/use-add.ts
@@ -2,8 +2,12 @@ import type { QueryClient } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { Route } from 'next';
 
-import type { ServiceLogPostRouteHandlerRequest } from '@/app/api/service-log/route';
+import type {
+  ServiceLogPostRouteHandlerRequest,
+  ServiceLogRouteHandlerResponse,
+} from '@/app/api/service-log/route';
 import type { CarServiceLogFormValues } from '@/car/schemas/zod/carServiceLogFormSchema';
+import type { ApiResponseBody } from '@/common/interface/api/response';
 import { useToasts } from '@/common/presentation/hook/use-toasts';
 import { httpClient } from '@/dependency/http-client';
 import { queryKeys } from '@/lib/tanstack/keys';
@@ -43,6 +47,13 @@ async function submitAddFormData(
   if (!postResult.success) {
     const { message } = postResult.error;
     throw new Error(message);
+  }
+
+  const body =
+    postResult.data as ApiResponseBody<ServiceLogRouteHandlerResponse>;
+
+  if (!body.success) {
+    throw new Error(`Request failed: ${body.error.message}`);
   }
 }
 

--- a/src/module/car/service-log/ui/forms/edit/use-edit.ts
+++ b/src/module/car/service-log/ui/forms/edit/use-edit.ts
@@ -2,8 +2,12 @@ import type { QueryClient } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { Route } from 'next';
 
-import type { ServiceLogPatchRouteHandlerRequest } from '@/app/api/service-log/route';
+import type {
+  ServiceLogPatchRouteHandlerRequest,
+  ServiceLogRouteHandlerResponse,
+} from '@/app/api/service-log/route';
 import type { CarServiceLogFormValues } from '@/car/schemas/zod/carServiceLogFormSchema';
+import type { ApiResponseBody } from '@/common/interface/api/response';
 import { useToasts } from '@/common/presentation/hook/use-toasts';
 import { httpClient } from '@/dependency/http-client';
 import { queryKeys } from '@/lib/tanstack/keys';
@@ -46,6 +50,13 @@ async function submitEditFormData(
   if (!patchResult.success) {
     const { message } = patchResult.error;
     throw new Error(message);
+  }
+
+  const body =
+    patchResult.data as ApiResponseBody<ServiceLogRouteHandlerResponse>;
+
+  if (!body.success) {
+    throw new Error(`Request failed: ${body.error.message}`);
   }
 }
 

--- a/src/module/car/ui/forms/add/use-add.ts
+++ b/src/module/car/ui/forms/add/use-add.ts
@@ -4,7 +4,7 @@ import type { Route } from 'next';
 
 import type { ApiCarResponse } from '@/app/api/car/route';
 import type { CarFormValues } from '@/car/schemas/zod/carFormSchema';
-import type { ApiResponseSuccessResult } from '@/common/interface/api/response';
+import type { ApiResponseBody } from '@/common/interface/api/response';
 import { useToasts } from '@/common/presentation/hook/use-toasts';
 import { httpClient } from '@/dependency/http-client';
 import { browserStorageClient } from '@/dependency/storage-client/browser';
@@ -41,11 +41,17 @@ async function submitAddForm(formData: CarFormValues) {
     throw new Error(message);
   }
 
+  const body = postResult.data as ApiResponseBody<ApiCarResponse>;
+
+  if (!body.success) {
+    throw new Error(`Request failed: ${body.error.message}`);
+  }
+
   if (!image) return;
 
   const {
     data: { id },
-  } = postResult.data as ApiResponseSuccessResult<ApiCarResponse>;
+  } = body;
 
   const hashedFile = await hashFile(image);
 

--- a/src/module/car/ui/forms/edit/use-edit.ts
+++ b/src/module/car/ui/forms/edit/use-edit.ts
@@ -4,7 +4,7 @@ import type { Route } from 'next';
 
 import type { ApiCarResponse } from '@/app/api/car/route';
 import type { CarFormValues } from '@/car/schemas/zod/carFormSchema';
-import type { ApiResponseSuccessResult } from '@/common/interface/api/response';
+import type { ApiResponseBody } from '@/common/interface/api/response';
 import { useToasts } from '@/common/presentation/hook/use-toasts';
 import { httpClient } from '@/dependency/http-client';
 import { browserStorageClient } from '@/dependency/storage-client/browser';
@@ -49,11 +49,17 @@ async function submitEditForm(carId: string, formData: CarFormValues) {
     throw new Error(message);
   }
 
+  const body = patchResult.data as ApiResponseBody<ApiCarResponse>;
+
+  if (!body.success) {
+    throw new Error(`Request failed: ${body.error.message}`);
+  }
+
   if (!image) return;
 
   const {
     data: { id },
-  } = patchResult.data as ApiResponseSuccessResult<ApiCarResponse>;
+  } = body;
 
   const hashedFile = await hashFile(image);
 


### PR DESCRIPTION
httpClient's fetch adapter returns Result.ok for any parseable HTTP response, including 4xx/5xx bodies, since it never checked response.ok. The API routes encode success/failure in the JSON body in sync with the HTTP status, so car and service-log add/edit hooks were treating server-rejected requests as successful.