### PR TITLE
fix(forms): resolve web/db type incompatibilities in car and service-log forms

### DIFF
--- a/src/app/api/car/route.ts
+++ b/src/app/api/car/route.ts
@@ -25,8 +25,10 @@ export async function POST(request: NextRequest) {
 
   const { carFormData } = (await request.json()) as ApiCarRequestBody;
 
+  let validatedCarFormData: CarFormValuesToValidate;
+
   try {
-    carFormSchema.parse(carFormData);
+    validatedCarFormData = carFormSchema.parse(carFormData);
   } catch (error) {
     if (error instanceof ZodError) {
       return errorApiResponse(
@@ -61,21 +63,23 @@ export async function POST(request: NextRequest) {
    */
   const rpcResult = await dbClient.rpc(async (rpc) =>
     rpc('create_new_car', {
-      additional_fuel_type: carFormData.additional_fuel_type || undefined,
-      custom_name: carFormData.custom_name || 'New car',
-      brand: carFormData.brand || undefined,
-      drive_type: carFormData.drive_type || undefined,
-      engine_capacity: carFormData.engine_capacity || undefined,
-      fuel_type: carFormData.fuel_type || undefined,
-      insurance_expiration: carFormData.insurance_expiration || undefined,
+      additional_fuel_type:
+        validatedCarFormData.additional_fuel_type ?? undefined,
+      custom_name: validatedCarFormData.custom_name || 'New car',
+      brand: validatedCarFormData.brand ?? undefined,
+      drive_type: validatedCarFormData.drive_type ?? undefined,
+      engine_capacity: validatedCarFormData.engine_capacity ?? undefined,
+      fuel_type: validatedCarFormData.fuel_type ?? undefined,
+      insurance_expiration:
+        validatedCarFormData.insurance_expiration ?? undefined,
       technical_inspection_expiration:
-        carFormData.technical_inspection_expiration || undefined,
-      license_plates: carFormData.license_plates || undefined,
-      mileage: carFormData.mileage || undefined,
-      model: carFormData.model || undefined,
-      production_year: carFormData.production_year || undefined,
-      transmission_type: carFormData.transmission_type || undefined,
-      vin: carFormData.vin || undefined,
+        validatedCarFormData.technical_inspection_expiration ?? undefined,
+      license_plates: validatedCarFormData.license_plates ?? undefined,
+      mileage: validatedCarFormData.mileage ?? undefined,
+      model: validatedCarFormData.model ?? undefined,
+      production_year: validatedCarFormData.production_year ?? undefined,
+      transmission_type: validatedCarFormData.transmission_type ?? undefined,
+      vin: validatedCarFormData.vin ?? undefined,
     }),
   );
 
@@ -95,8 +99,10 @@ export async function PATCH(request: NextRequest) {
 
   const { carFormData, carId } = (await request.json()) as ApiCarRequestBody;
 
+  let validatedCarFormData: CarFormValuesToValidate;
+
   try {
-    carFormSchema.parse(carFormData);
+    validatedCarFormData = carFormSchema.parse(carFormData);
   } catch (error) {
     if (error instanceof ZodError) {
       return errorApiResponse(
@@ -123,21 +129,21 @@ export async function PATCH(request: NextRequest) {
   const queryResult = await dbClient.query(async (from) =>
     from('cars')
       .update({
-        custom_name: carFormData.custom_name,
-        brand: carFormData.brand || undefined,
-        model: carFormData.model || undefined,
-        production_year: carFormData.production_year || undefined,
-        engine_capacity: carFormData.engine_capacity || undefined,
-        fuel_type: carFormData.fuel_type || undefined,
-        additional_fuel_type: carFormData.additional_fuel_type || undefined,
-        drive_type: carFormData.drive_type || undefined,
-        transmission_type: carFormData.transmission_type || undefined,
-        license_plates: carFormData.license_plates || undefined,
-        vin: carFormData.vin || undefined,
-        mileage: carFormData.mileage || undefined,
-        insurance_expiration: carFormData.insurance_expiration || undefined,
+        custom_name: validatedCarFormData.custom_name,
+        brand: validatedCarFormData.brand,
+        model: validatedCarFormData.model,
+        production_year: validatedCarFormData.production_year,
+        engine_capacity: validatedCarFormData.engine_capacity,
+        fuel_type: validatedCarFormData.fuel_type,
+        additional_fuel_type: validatedCarFormData.additional_fuel_type,
+        drive_type: validatedCarFormData.drive_type,
+        transmission_type: validatedCarFormData.transmission_type,
+        license_plates: validatedCarFormData.license_plates,
+        vin: validatedCarFormData.vin,
+        mileage: validatedCarFormData.mileage,
+        insurance_expiration: validatedCarFormData.insurance_expiration,
         technical_inspection_expiration:
-          carFormData.technical_inspection_expiration || undefined,
+          validatedCarFormData.technical_inspection_expiration,
       })
       .eq('id', carId || '')
       .select('id')

--- a/src/app/api/service-log/route.ts
+++ b/src/app/api/service-log/route.ts
@@ -58,8 +58,10 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  let validatedFormData: CarServiceLogFormValues;
+
   try {
-    carServiceLogFormSchema.parse(formData);
+    validatedFormData = carServiceLogFormSchema.parse(formData);
   } catch (error) {
     if (error instanceof ZodError) {
       return errorApiResponse(
@@ -99,7 +101,7 @@ export async function POST(request: NextRequest) {
   const queryResult = await dbClient.query(async (from) =>
     from('service_logs')
       .insert({
-        ...formData,
+        ...validatedFormData,
         created_by: authIdentity.id,
         car_id,
       })
@@ -149,8 +151,10 @@ export async function PATCH(request: NextRequest) {
     );
   }
 
+  let validatedFormData: CarServiceLogFormValues;
+
   try {
-    carServiceLogFormSchema.parse(formData);
+    validatedFormData = carServiceLogFormSchema.parse(formData);
   } catch (error) {
     if (error instanceof ZodError) {
       return errorApiResponse(
@@ -178,7 +182,7 @@ export async function PATCH(request: NextRequest) {
 
   const queryResult = await dbClient.query(async (from) =>
     from('service_logs')
-      .update({ ...formData })
+      .update({ ...validatedFormData })
       .eq('id', service_log_id)
       .select('id')
       .single(),

--- a/src/common/interface/schema/nullify.schema.ts
+++ b/src/common/interface/schema/nullify.schema.ts
@@ -1,0 +1,17 @@
+import type { ZodType } from 'zod';
+import { z } from 'zod';
+
+z.config({
+  jitless: true,
+});
+
+export function nullifyEmptyString<T extends ZodType>(schema: T) {
+  return z.preprocess((val) => (val === '' ? null : val), schema.nullable());
+}
+
+export function nullifyNaN<T extends ZodType>(schema: T) {
+  return z.preprocess(
+    (val) => (typeof val === 'number' && Number.isNaN(val) ? null : val),
+    schema.nullable(),
+  );
+}

--- a/src/module/car/schemas/zod/carFormSchema.ts
+++ b/src/module/car/schemas/zod/carFormSchema.ts
@@ -2,6 +2,10 @@ import type { ZodType } from 'zod';
 import { z } from 'zod';
 
 import { imageFileSchema } from '@/common/interface/schema/image-file.schema';
+import {
+  nullifyEmptyString,
+  nullifyNaN,
+} from '@/common/interface/schema/nullify.schema';
 import { parseDateToYyyyMmDd } from '@/lib/utils';
 import type {
   Car,
@@ -25,17 +29,6 @@ type CarFormSchemaShape = Omit<
 z.config({
   jitless: true,
 });
-
-function nullifyEmptyString<T extends ZodType>(schema: T) {
-  return z.preprocess((val) => (val === '' ? null : val), schema.nullable());
-}
-
-function nullifyNaN<T extends ZodType>(schema: T) {
-  return z.preprocess(
-    (val) => (typeof val === 'number' && Number.isNaN(val) ? null : val),
-    schema.nullable(),
-  );
-}
 
 // Postgres "integer" (int4) upper bound; engine_capacity and mileage columns are int4.
 export const POSTGRES_INT4_MAX_VALUE = 2147483647;

--- a/src/module/car/schemas/zod/carFormSchema.ts
+++ b/src/module/car/schemas/zod/carFormSchema.ts
@@ -37,6 +37,9 @@ function nullifyNaN<T extends ZodType>(schema: T) {
   );
 }
 
+// Postgres "integer" (int4) upper bound; engine_capacity and mileage columns are int4.
+export const POSTGRES_INT4_MAX_VALUE = 2147483647;
+
 const CAR_NAME_REQUIRED_MESSAGE = 'Name is required.';
 const CAR_NAME_TYPE_MESSAGE = 'Name must be a string.';
 export const MIN_CAR_NAME_LENGTH = 1;
@@ -134,8 +137,10 @@ const CAR_ENGINE_CAPACITY_TYPE_MESSAGE = 'Engine capacity must be a number.';
 export const MIN_CAR_ENGINE_CAPACITY_VALUE = 1;
 const MIN_CAR_ENGINE_CAPACITY_VALUE_MESSAGE =
   'Engine capacity must be a positive number.';
-export const MAX_CAR_ENGINE_CAPACITY_VALUE = Number.MAX_SAFE_INTEGER;
-const CAR_ENGINE_CAPACITY_VALUE_RANGE_MESSAGE = `Engine capacity value must be between ${Number.MIN_SAFE_INTEGER} and ${MAX_CAR_ENGINE_CAPACITY_VALUE}.`;
+export const MAX_CAR_ENGINE_CAPACITY_VALUE = POSTGRES_INT4_MAX_VALUE;
+const MAX_CAR_ENGINE_CAPACITY_VALUE_MESSAGE = `Maximum engine capacity is ${MAX_CAR_ENGINE_CAPACITY_VALUE}.`;
+const CAR_ENGINE_CAPACITY_NOT_INTEGER_MESSAGE =
+  'Engine capacity must be a whole number.';
 
 const carEngineCapacitySchema = z
   .number({
@@ -147,15 +152,19 @@ const carEngineCapacitySchema = z
   .min(MIN_CAR_ENGINE_CAPACITY_VALUE, {
     error: MIN_CAR_ENGINE_CAPACITY_VALUE_MESSAGE,
   })
+  .max(MAX_CAR_ENGINE_CAPACITY_VALUE, {
+    error: MAX_CAR_ENGINE_CAPACITY_VALUE_MESSAGE,
+  })
   .nonnegative({ error: MIN_CAR_ENGINE_CAPACITY_VALUE_MESSAGE })
-  .int({ error: CAR_ENGINE_CAPACITY_VALUE_RANGE_MESSAGE });
+  .int({ error: CAR_ENGINE_CAPACITY_NOT_INTEGER_MESSAGE });
 
 const CAR_MILEAGE_REQUIRED_MESSAGE = 'Mileage is required.';
 const CAR_MILEAGE_TYPE_MESSAGE = 'Mileage must be a number.';
 export const MIN_CAR_MILEAGE_VALUE = 1;
 const MIN_CAR_MILEAGE_VALUE_MESSAGE = 'Mileage must be positive number.';
-export const MAX_CAR_MILEAGE_VALUE = Number.MAX_SAFE_INTEGER;
-const CAR_MILEAGE_VALUE_RANGE_MESSAGE = `Mileage value must be between ${Number.MIN_SAFE_INTEGER} and ${MAX_CAR_MILEAGE_VALUE}.`;
+export const MAX_CAR_MILEAGE_VALUE = POSTGRES_INT4_MAX_VALUE;
+const MAX_CAR_MILEAGE_VALUE_MESSAGE = `Maximum mileage is ${MAX_CAR_MILEAGE_VALUE}.`;
+const CAR_MILEAGE_NOT_INTEGER_MESSAGE = 'Mileage must be a whole number.';
 
 export const carMileageSchema = z
   .number({
@@ -165,8 +174,9 @@ export const carMileageSchema = z
         : CAR_MILEAGE_TYPE_MESSAGE,
   })
   .min(MIN_CAR_MILEAGE_VALUE, { error: MIN_CAR_MILEAGE_VALUE_MESSAGE })
+  .max(MAX_CAR_MILEAGE_VALUE, { error: MAX_CAR_MILEAGE_VALUE_MESSAGE })
   .nonnegative({ error: MIN_CAR_MILEAGE_VALUE_MESSAGE })
-  .int({ error: CAR_MILEAGE_VALUE_RANGE_MESSAGE });
+  .int({ error: CAR_MILEAGE_NOT_INTEGER_MESSAGE });
 
 const CAR_PRODUCTION_YEAR_REQUIRED_MESSAGE = 'Production year is required.';
 const CAR_PRODUCTION_YEAR_TYPE_MESSAGE = 'Production year must be a number.';
@@ -177,7 +187,8 @@ export const MIN_CAR_PRODUCTION_YEAR_VALUE_MESSAGE =
   'Hey! First car was made in 1885.';
 export const MAX_CAR_PRODUCTION_YEAR_VALUE = new Date().getFullYear() + 5;
 const MAX_CAR_PRODUCTION_YEAR_VALUE_MESSAGE = `Maximum production year is ${MAX_CAR_PRODUCTION_YEAR_VALUE}.`;
-const CAR_PRODUCTION_YEAR_VALUE_RANGE_MESSAGE = `Production year value must be between ${Number.MIN_SAFE_INTEGER} and ${Number.MAX_SAFE_INTEGER}.`;
+const CAR_PRODUCTION_YEAR_NOT_INTEGER_MESSAGE =
+  'Production year must be a whole number.';
 
 const carProductionYearSchema = z
   .number({
@@ -193,7 +204,7 @@ const carProductionYearSchema = z
     error: MAX_CAR_PRODUCTION_YEAR_VALUE_MESSAGE,
   })
   .nonnegative({ error: CAR_PRODUCTION_YEAR_NONNEGATIVE_MESSAGE })
-  .int({ error: CAR_PRODUCTION_YEAR_VALUE_RANGE_MESSAGE });
+  .int({ error: CAR_PRODUCTION_YEAR_NOT_INTEGER_MESSAGE });
 
 const carFuelEnumSchema = z.enum(
   Object.values(fuelTypesMapping) as [keyof FuelMapping],

--- a/src/module/car/schemas/zod/carFormSchema.ts
+++ b/src/module/car/schemas/zod/carFormSchema.ts
@@ -26,6 +26,17 @@ z.config({
   jitless: true,
 });
 
+function nullifyEmptyString<T extends ZodType>(schema: T) {
+  return z.preprocess((val) => (val === '' ? null : val), schema.nullable());
+}
+
+function nullifyNaN<T extends ZodType>(schema: T) {
+  return z.preprocess(
+    (val) => (typeof val === 'number' && Number.isNaN(val) ? null : val),
+    schema.nullable(),
+  );
+}
+
 const CAR_NAME_REQUIRED_MESSAGE = 'Name is required.';
 const CAR_NAME_TYPE_MESSAGE = 'Name must be a string.';
 export const MIN_CAR_NAME_LENGTH = 1;
@@ -201,20 +212,11 @@ const carDriveEnumSchema = z.enum(
   },
 );
 
-const carFuelTypeSchema = z
-  .string()
-  .transform((val) => (val === '' ? null : val))
-  .pipe(carFuelEnumSchema.nullable());
+const carFuelTypeSchema = nullifyEmptyString(carFuelEnumSchema);
 
-const carTransmissionTypeSchema = z
-  .string()
-  .transform((val) => (val === '' ? null : val))
-  .pipe(carTransmissionEnumSchema.nullable());
+const carTransmissionTypeSchema = nullifyEmptyString(carTransmissionEnumSchema);
 
-const carDriveTypeSchema = z
-  .string()
-  .transform((val) => (val === '' ? null : val))
-  .pipe(carDriveEnumSchema.nullable());
+const carDriveTypeSchema = nullifyEmptyString(carDriveEnumSchema);
 
 const CAR_INSURANCE_EXPIRATION_DATE_REQUIRED_MESSAGE =
   'Insurance expiration date is required.';
@@ -252,28 +254,26 @@ const carTechnicalInspectionExpirationSchema = z.coerce
   .min(new Date(MIN_CAR_TECHNICAL_INSPECTION_EXPIRATION_DATE), {
     error: MIN_CAR_TECHNICAL_INSPECTION_EXPIRATION_DATE_MESSAGE,
   })
-  .transform((date) => (date ? parseDateToYyyyMmDd(date) : null));
+  .transform((date) => parseDateToYyyyMmDd(date));
 
 export const carFormSchema = z.object({
   image: imageFileSchema.nullable().optional(),
   custom_name: carNameSchema,
-  brand: carBrandSchema.nullable().or(z.literal('')),
-  model: carModelSchema.nullable().or(z.literal('')),
-  license_plates: carLicensePlatesSchema.nullable().or(z.literal('')),
-  vin: carVinSchema.nullable().or(z.literal('')),
-  engine_capacity: carEngineCapacitySchema.nullable().or(z.nan()),
-  mileage: carMileageSchema.nullable().or(z.nan()),
-  production_year: carProductionYearSchema.nullable().or(z.nan()),
-  fuel_type: carFuelTypeSchema.nullable(),
-  additional_fuel_type: carFuelTypeSchema.nullable(),
-  transmission_type: carTransmissionTypeSchema.nullable(),
-  drive_type: carDriveTypeSchema.nullable(),
-  insurance_expiration: carInsuranceExpirationSchema
-    .nullable()
-    .or(z.literal('')),
-  technical_inspection_expiration: carTechnicalInspectionExpirationSchema
-    .nullable()
-    .or(z.literal('')),
+  brand: nullifyEmptyString(carBrandSchema),
+  model: nullifyEmptyString(carModelSchema),
+  license_plates: nullifyEmptyString(carLicensePlatesSchema),
+  vin: nullifyEmptyString(carVinSchema),
+  engine_capacity: nullifyNaN(carEngineCapacitySchema),
+  mileage: nullifyNaN(carMileageSchema),
+  production_year: nullifyNaN(carProductionYearSchema),
+  fuel_type: carFuelTypeSchema,
+  additional_fuel_type: carFuelTypeSchema,
+  transmission_type: carTransmissionTypeSchema,
+  drive_type: carDriveTypeSchema,
+  insurance_expiration: nullifyEmptyString(carInsuranceExpirationSchema),
+  technical_inspection_expiration: nullifyEmptyString(
+    carTechnicalInspectionExpirationSchema,
+  ),
 } satisfies CarFormSchemaShape);
 
 export type CarFormValues = z.infer<typeof carFormSchema>;

--- a/src/module/car/schemas/zod/carServiceLogFormSchema.ts
+++ b/src/module/car/schemas/zod/carServiceLogFormSchema.ts
@@ -1,6 +1,10 @@
 import type { ZodType } from 'zod';
 import { z } from 'zod';
 
+import {
+  nullifyEmptyString,
+  nullifyNaN,
+} from '@/common/interface/schema/nullify.schema';
 import { parseDateToYyyyMmDd } from '@/lib/utils';
 import type { ServiceCategoryMapping, ServiceLog } from '@/types';
 import { serviceCategoryMapping } from '@/types';
@@ -45,6 +49,7 @@ const SERVICE_COST_REQUIRED_MESSAGE = 'Cost is required.';
 const SERVICE_COST_TYPE_MESSAGE = 'Cost must be a number.';
 const SERVICE_COST_NONNEGATIVE_MESSAGE =
   'Service cost must be a positive number.';
+const SERVICE_COST_SCALE_MESSAGE = 'Cost must have at most 2 decimal places.';
 
 const serviceCostSchema = z
   .number({
@@ -53,7 +58,8 @@ const serviceCostSchema = z
         ? SERVICE_COST_REQUIRED_MESSAGE
         : SERVICE_COST_TYPE_MESSAGE,
   })
-  .nonnegative({ error: SERVICE_COST_NONNEGATIVE_MESSAGE });
+  .nonnegative({ error: SERVICE_COST_NONNEGATIVE_MESSAGE })
+  .multipleOf(0.01, { error: SERVICE_COST_SCALE_MESSAGE });
 
 const SERVICE_DATE_REQUIRED_MESSAGE = 'Date is required.';
 const SERVICE_DATE_TYPE_MESSAGE = 'Invalid date.';
@@ -75,9 +81,9 @@ const serviceDateSchema = z.coerce
 export const carServiceLogFormSchema = z.object({
   service_date: serviceDateSchema,
   category: serviceCategorySchema,
-  mileage: carMileageSchema.nullable().or(z.nan()),
-  notes: serviceNoteSchema.nullable().or(z.literal('')),
-  service_cost: serviceCostSchema.nullable().or(z.nan()),
+  mileage: nullifyNaN(carMileageSchema),
+  notes: nullifyEmptyString(serviceNoteSchema),
+  service_cost: nullifyNaN(serviceCostSchema),
 } satisfies CarServiceLogFormSchemaShape);
 
 export type CarServiceLogFormValues = z.infer<typeof carServiceLogFormSchema>;


### PR DESCRIPTION
Postgres check constraints and column types silently rejected values that
passed client- and server-side Zod validation, surfacing as raw DB errors
(check constraint violations, invalid date syntax, integer out of range)
instead of clean validation messages.

- Car and service-log forms now normalize ''/NaN to null via shared
  nullifyEmptyString/nullifyNaN helpers (common/interface/schema/nullify.schema.ts)
  instead of letting empty values pass through unchanged, fixing model,
  license_plates, vin, insurance/technical-inspection dates, mileage, notes,
  and service_cost.
- engine_capacity and mileage now enforce Postgres's int4 range (previously
  unbounded beyond Number.MAX_SAFE_INTEGER, with no .max() check at all).
- service_cost enforces the DB's 2-decimal-place scale constraint.
- Both car and service-log API routes now write the schema's validated
  output instead of the raw request body, so normalization applies
  regardless of caller.