### PR TITLE
refactor(test): type mocks from their interfaces

### DIFF
--- a/src/common/application/auth-client.mock.ts
+++ b/src/common/application/auth-client.mock.ts
@@ -1,27 +1,29 @@
+import { jest } from '@jest/globals';
+
 import type {
   AdminAuthClient,
   AuthClient,
 } from '@/common/application/auth-client';
 
-export function createMockAuthClient() {
+export function createMockAuthClient(): jest.Mocked<AuthClient> {
   return {
-    authenticate: jest.fn(),
-    changePassword: jest.fn(),
-    exchangeCodeForSession: jest.fn(),
-    resetPassword: jest.fn(),
-    sendConfirmationEmail: jest.fn(),
-    signIn: jest.fn(),
-    signInWithOAuth: jest.fn(),
-    signOut: jest.fn(),
-    signUp: jest.fn(),
-    verifyOtp: jest.fn(),
-  } as jest.Mocked<AuthClient>;
+    authenticate: jest.fn<AuthClient['authenticate']>(),
+    changePassword: jest.fn<AuthClient['changePassword']>(),
+    exchangeCodeForSession: jest.fn<AuthClient['exchangeCodeForSession']>(),
+    resetPassword: jest.fn<AuthClient['resetPassword']>(),
+    sendConfirmationEmail: jest.fn<AuthClient['sendConfirmationEmail']>(),
+    signIn: jest.fn<AuthClient['signIn']>(),
+    signInWithOAuth: jest.fn<AuthClient['signInWithOAuth']>(),
+    signOut: jest.fn<AuthClient['signOut']>(),
+    signUp: jest.fn<AuthClient['signUp']>(),
+    verifyOtp: jest.fn<AuthClient['verifyOtp']>(),
+  };
 }
 
-export function createMockAdminAuthClient() {
+export function createMockAdminAuthClient(): jest.Mocked<AdminAuthClient> {
   return {
     ...createMockAuthClient(),
-    createAuthIdentity: jest.fn(),
-    deleteAuthIdentity: jest.fn(),
-  } as jest.Mocked<AdminAuthClient>;
+    createAuthIdentity: jest.fn<AdminAuthClient['createAuthIdentity']>(),
+    deleteAuthIdentity: jest.fn<AdminAuthClient['deleteAuthIdentity']>(),
+  };
 }

--- a/src/common/application/http-client.mock.ts
+++ b/src/common/application/http-client.mock.ts
@@ -1,12 +1,14 @@
+import { jest } from '@jest/globals';
+
 import type { HttpClient } from '@/common/application/http-client';
 
-export function createMockHttpClient() {
+export function createMockHttpClient(): jest.Mocked<HttpClient> {
   return {
-    get: jest.fn(),
-    post: jest.fn(),
-    put: jest.fn(),
-    delete: jest.fn(),
-    patch: jest.fn(),
-    getController: jest.fn(),
-  } as jest.Mocked<HttpClient>;
+    get: jest.fn<HttpClient['get']>(),
+    post: jest.fn<HttpClient['post']>(),
+    put: jest.fn<HttpClient['put']>(),
+    delete: jest.fn<HttpClient['delete']>(),
+    patch: jest.fn<HttpClient['patch']>(),
+    getController: jest.fn<HttpClient['getController']>(),
+  };
 }

--- a/src/common/application/validator.mock.ts
+++ b/src/common/application/validator.mock.ts
@@ -1,7 +1,12 @@
+import { jest } from '@jest/globals';
+
 import type { Validator } from '@/common/application/validator';
 
-export function createMockValidator() {
+export function createMockValidator(): jest.Mocked<Validator> {
   return {
-    validate: jest.fn(),
-  } as jest.Mocked<Validator>;
+    // `validate` is generic. A mock fixes its type parameter at creation, so no
+    // mock call signature can match the generic one. The cast is scoped to this
+    // member, leaving the surrounding object checked against `Validator`.
+    validate: jest.fn() as unknown as jest.Mocked<Validator>['validate'],
+  };
 }

--- a/src/common/infrastructure/database-client/supabase.mock.ts
+++ b/src/common/infrastructure/database-client/supabase.mock.ts
@@ -1,5 +1,16 @@
+import { jest } from '@jest/globals';
+
 import type { SupabaseDatabaseClient } from '@/common/infrastructure/database-client/supabase';
 
+/**
+ * Unlike the other doubles in this codebase, this one cannot be checked against
+ * its subject. `SupabaseDatabaseClient` is a class holding a private `_client`,
+ * which is nominal and unreachable from an object literal, and its `query` and
+ * `rpc` are generic, so a mock (which fixes the type parameter at creation) can
+ * never match their call signatures. Both force the assertion below, which means
+ * a method added to the client will not fail here. Keep this mock in step by
+ * hand.
+ */
 export function createMockSupabaseDatabaseClient() {
   return {
     query: jest.fn(),

--- a/src/module/car/application/mapper/car.mock.ts
+++ b/src/module/car/application/mapper/car.mock.ts
@@ -1,10 +1,12 @@
+import { jest } from '@jest/globals';
+
 import type { CarMapper } from '@/car/application/mapper/car';
 
-export function createMockCarMapper() {
+export function createMockCarMapper(): jest.Mocked<CarMapper> {
   return {
-    domainToDto: jest.fn(),
-    domainToPersistence: jest.fn(),
-    persistenceToDomain: jest.fn(),
-    persistenceToDto: jest.fn(),
-  } as unknown as jest.Mocked<CarMapper>;
+    domainToDto: jest.fn<CarMapper['domainToDto']>(),
+    domainToPersistence: jest.fn<CarMapper['domainToPersistence']>(),
+    persistenceToDomain: jest.fn<CarMapper['persistenceToDomain']>(),
+    persistenceToDto: jest.fn<CarMapper['persistenceToDto']>(),
+  };
 }

--- a/src/module/car/application/provisioning/car.mock.ts
+++ b/src/module/car/application/provisioning/car.mock.ts
@@ -1,7 +1,10 @@
+import { jest } from '@jest/globals';
+
 import type { CarProvisioning } from '@/car/application/provisioning/car';
 
-export function createMockCarProvisioning() {
+export function createMockCarProvisioning(): jest.Mocked<CarProvisioning> {
   return {
-    createWithPrimaryOwner: jest.fn(),
-  } as unknown as jest.Mocked<CarProvisioning>;
+    createWithPrimaryOwner:
+      jest.fn<CarProvisioning['createWithPrimaryOwner']>(),
+  };
 }

--- a/src/module/car/application/repository/car.mock.ts
+++ b/src/module/car/application/repository/car.mock.ts
@@ -1,10 +1,12 @@
+import { jest } from '@jest/globals';
+
 import type { CarRepository } from '@/car/application/repository/car';
 
-export function createMockCarRepository() {
+export function createMockCarRepository(): jest.Mocked<CarRepository> {
   return {
-    getById: jest.fn(),
-    update: jest.fn(),
-    store: jest.fn(),
-    remove: jest.fn(),
-  } as unknown as jest.Mocked<CarRepository>;
+    getById: jest.fn<CarRepository['getById']>(),
+    update: jest.fn<CarRepository['update']>(),
+    store: jest.fn<CarRepository['store']>(),
+    remove: jest.fn<CarRepository['remove']>(),
+  };
 }

--- a/src/module/car/ownership/application/mapper/ownership.mock.ts
+++ b/src/module/car/ownership/application/mapper/ownership.mock.ts
@@ -1,11 +1,15 @@
+import { jest } from '@jest/globals';
+
 import type { OwnershipMapper } from '@/car/ownership/application/mapper/ownership';
 
-export function createMockOwnershipMapper() {
+export function createMockOwnershipMapper(): jest.Mocked<OwnershipMapper> {
   return {
-    domainToDto: jest.fn(),
-    persistenceToDomain: jest.fn(),
-    persistenceToDto: jest.fn(),
-    newCoOwnerToPersistence: jest.fn(),
-    primaryOwnerToPersistence: jest.fn(),
-  } as unknown as jest.Mocked<OwnershipMapper>;
+    domainToDto: jest.fn<OwnershipMapper['domainToDto']>(),
+    persistenceToDomain: jest.fn<OwnershipMapper['persistenceToDomain']>(),
+    persistenceToDto: jest.fn<OwnershipMapper['persistenceToDto']>(),
+    newCoOwnerToPersistence:
+      jest.fn<OwnershipMapper['newCoOwnerToPersistence']>(),
+    primaryOwnerToPersistence:
+      jest.fn<OwnershipMapper['primaryOwnerToPersistence']>(),
+  };
 }

--- a/src/module/car/ownership/application/repository/ownership.mock.ts
+++ b/src/module/car/ownership/application/repository/ownership.mock.ts
@@ -1,10 +1,12 @@
+import { jest } from '@jest/globals';
+
 import type { OwnershipRepository } from '@/car/ownership/application/repository/ownership';
 
-export function createMockOwnershipRepository() {
+export function createMockOwnershipRepository(): jest.Mocked<OwnershipRepository> {
   return {
-    getByCarId: jest.fn(),
-    addOwner: jest.fn(),
-    removeOwner: jest.fn(),
-    promotePrimary: jest.fn(),
-  } as unknown as jest.Mocked<OwnershipRepository>;
+    getByCarId: jest.fn<OwnershipRepository['getByCarId']>(),
+    addOwner: jest.fn<OwnershipRepository['addOwner']>(),
+    removeOwner: jest.fn<OwnershipRepository['removeOwner']>(),
+    promotePrimary: jest.fn<OwnershipRepository['promotePrimary']>(),
+  };
 }

--- a/src/module/car/service-log/application/mapper/service-log.mock.ts
+++ b/src/module/car/service-log/application/mapper/service-log.mock.ts
@@ -1,10 +1,12 @@
+import { jest } from '@jest/globals';
+
 import type { ServiceLogMapper } from '@/car/service-log/application/mapper/service-log';
 
-export function createMockServiceLogMapper() {
+export function createMockServiceLogMapper(): jest.Mocked<ServiceLogMapper> {
   return {
-    domainToDto: jest.fn(),
-    domainToPersistence: jest.fn(),
-    persistenceToDomain: jest.fn(),
-    persistenceToDto: jest.fn(),
-  } as unknown as jest.Mocked<ServiceLogMapper>;
+    domainToDto: jest.fn<ServiceLogMapper['domainToDto']>(),
+    domainToPersistence: jest.fn<ServiceLogMapper['domainToPersistence']>(),
+    persistenceToDomain: jest.fn<ServiceLogMapper['persistenceToDomain']>(),
+    persistenceToDto: jest.fn<ServiceLogMapper['persistenceToDto']>(),
+  };
 }

--- a/src/module/car/service-log/application/reader/car-ownership.mock.ts
+++ b/src/module/car/service-log/application/reader/car-ownership.mock.ts
@@ -1,7 +1,9 @@
+import { jest } from '@jest/globals';
+
 import type { CarOwnershipReader } from '@/car/service-log/application/reader/car-ownership';
 
-export function createMockCarOwnershipReader() {
+export function createMockCarOwnershipReader(): jest.Mocked<CarOwnershipReader> {
   return {
-    getByCarId: jest.fn(),
-  } as unknown as jest.Mocked<CarOwnershipReader>;
+    getByCarId: jest.fn<CarOwnershipReader['getByCarId']>(),
+  };
 }

--- a/src/module/car/service-log/application/repository/service-log.mock.ts
+++ b/src/module/car/service-log/application/repository/service-log.mock.ts
@@ -1,10 +1,12 @@
+import { jest } from '@jest/globals';
+
 import type { ServiceLogRepository } from '@/car/service-log/application/repository/service-log';
 
-export function createMockServiceLogRepository() {
+export function createMockServiceLogRepository(): jest.Mocked<ServiceLogRepository> {
   return {
-    store: jest.fn(),
-    getById: jest.fn(),
-    update: jest.fn(),
-    remove: jest.fn(),
-  } as unknown as jest.Mocked<ServiceLogRepository>;
+    store: jest.fn<ServiceLogRepository['store']>(),
+    getById: jest.fn<ServiceLogRepository['getById']>(),
+    update: jest.fn<ServiceLogRepository['update']>(),
+    remove: jest.fn<ServiceLogRepository['remove']>(),
+  };
 }

--- a/src/module/car/service-log/presentation/ui/forms/edit/edit.test.tsx
+++ b/src/module/car/service-log/presentation/ui/forms/edit/edit.test.tsx
@@ -34,32 +34,36 @@ function TestEditForm() {
 }
 
 describe('EditForm', () => {
-  it('should render the service log fields prefilled from the service log', () => {
+  it('should render the service log fields prefilled from the service log', async () => {
     render(<TestEditForm />);
 
-    expect(screen.getByLabelText(/date/i)).toHaveValue('2026-01-01');
+    expect(await screen.findByLabelText(/date/i)).toHaveValue('2026-01-01');
     expect(screen.getByLabelText(/mileage/i)).toHaveValue(50000);
     expect(screen.getByLabelText(/notes/i)).toHaveValue('Oil change');
     expect(screen.getByLabelText(/cost/i)).toHaveValue(100);
     expect(screen.getByRole('checkbox', { name: /engine/i })).toBeChecked();
   });
 
-  it('should render a form reset button', () => {
+  it('should render a form reset button', async () => {
     render(<TestEditForm />);
 
-    expect(screen.getByRole('button', { name: 'Reset' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Reset' }),
+    ).toBeInTheDocument();
   });
 
-  it('should render a form submit button', () => {
+  it('should render a form submit button', async () => {
     render(<TestEditForm />);
 
-    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Save' }),
+    ).toBeInTheDocument();
   });
 
-  it('initially form controls should be disabled', () => {
+  it('initially form controls should be disabled', async () => {
     render(<TestEditForm />);
 
-    expect(screen.getByRole('button', { name: 'Reset' })).toBeDisabled();
+    expect(await screen.findByRole('button', { name: 'Reset' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
   });
 

--- a/src/module/user/application/mapper/user.mock.ts
+++ b/src/module/user/application/mapper/user.mock.ts
@@ -1,11 +1,13 @@
+import { jest } from '@jest/globals';
+
 import type { UserMapper } from '@/user/application/mapper/user';
 
-export function createMockUserMapper() {
+export function createMockUserMapper(): jest.Mocked<UserMapper> {
   return {
-    authIdentityToDomain: jest.fn(),
-    domainToDto: jest.fn(),
-    domainToPersistence: jest.fn(),
-    persistenceToDomain: jest.fn(),
-    persistenceToDto: jest.fn(),
-  } as unknown as jest.Mocked<UserMapper>;
+    authIdentityToDomain: jest.fn<UserMapper['authIdentityToDomain']>(),
+    domainToDto: jest.fn<UserMapper['domainToDto']>(),
+    domainToPersistence: jest.fn<UserMapper['domainToPersistence']>(),
+    persistenceToDomain: jest.fn<UserMapper['persistenceToDomain']>(),
+    persistenceToDto: jest.fn<UserMapper['persistenceToDto']>(),
+  };
 }

--- a/src/module/user/application/repository/user.mock.ts
+++ b/src/module/user/application/repository/user.mock.ts
@@ -1,10 +1,12 @@
+import { jest } from '@jest/globals';
+
 import type { UserRepository } from '@/user/application/repository/user';
 
-export function createMockUserRepository() {
+export function createMockUserRepository(): jest.Mocked<UserRepository> {
   return {
-    getById: jest.fn(),
-    update: jest.fn(),
-    store: jest.fn(),
-    remove: jest.fn(),
-  } as unknown as jest.Mocked<UserRepository>;
+    getById: jest.fn<UserRepository['getById']>(),
+    update: jest.fn<UserRepository['update']>(),
+    store: jest.fn<UserRepository['store']>(),
+    remove: jest.fn<UserRepository['remove']>(),
+  };
 }

--- a/src/module/user/application/repository/user.mock.ts
+++ b/src/module/user/application/repository/user.mock.ts
@@ -5,5 +5,6 @@ export function createMockUserRepository() {
     getById: jest.fn(),
     update: jest.fn(),
     store: jest.fn(),
+    remove: jest.fn(),
   } as unknown as jest.Mocked<UserRepository>;
 }


### PR DESCRIPTION
## Summary

- Mock factories derive each member's type from the interface they double, replacing the assertion onto `jest.Mocked`. A mock that omits an interface method, misspells one, or stubs a wrong signature now fails type-check.
- Adds the missing `remove` to the user repository mock. `UserRepository` extends `Repository<User>`, which requires it; the previous assertion hid the gap.
- `validator.mock.ts` and `supabase.mock.ts` keep assertions, narrowed to the members that force them.
- Clears the last `act()` warnings in the suite, from the `EditForm` tests.

## Why

`@types/jest` types `jest.fn` as `fn<TReturn, TArgs>`, which cannot accept a method type. Every mock therefore asserted its object literal onto `jest.Mocked`, and that assertion suppressed conformance checking entirely: the doubles were free to drift from their subjects with no error, which is how the user repository mock lost `remove`. The `jest.fn` shipped with jest takes the whole function type, so the members can be typed from the interface directly and the assertion is no longer needed.

## Key points

- Mock factories import `jest` from `@jest/globals`. Test files keep using the ambient `@types/jest` globals, and the two are structurally compatible. This is a boundary rather than a half-finished migration: mock types are what needed fixing, and call sites were already typed correctly through the factories' return types.
- `@jest/globals` is resolved transitively through jest rather than declared. Declaring it independently would pin a version against jest's own exact internal pin, which silently installs a second copy of `@jest/globals` and `jest-mock` once the two drift.
- A mock fixes a generic method's type parameter at creation, so its call signature can never match the generic one. `Validator.validate` and the supabase client's `query` and `rpc` hit this, and the supabase client additionally holds a private field that no object literal can satisfy, so its assertion stays at object level and the mock has to be maintained by hand.
- `ServiceLogForm` runs an async zod resolver on mount and subscribes to `isValid`. `EditForm` is prefilled with valid values, so `isValid` flips after the resolver settles and the synchronous tests had already finished. Those tests now await their first query. The add form never warned, because its empty defaults stay invalid and leave `isValid` unchanged.