### PR TITLE
style: fix overflow and truncation, dedupe components

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ export default async function RootLayout({
   return (
     <html
       suppressHydrationWarning
-      className="[scrollbar-gutter:stable]"
+      className="scrollbar-thin scrollbar-gutter-stable"
       lang="en"
     >
       <body

--- a/src/common/presentation/ui/badge/badge.tsx
+++ b/src/common/presentation/ui/badge/badge.tsx
@@ -1,0 +1,34 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+type BadgeProps = ComponentProps<'div'> & {
+  label: string;
+  image: ReactNode;
+};
+
+/**
+ * A label next to a round image, sized to fit whatever box it is dropped into.
+ * Callers control the order with `flex-row-reverse`.
+ */
+export function Badge({ label, image, className, ...props }: BadgeProps) {
+  return (
+    <div
+      className={twMerge('flex min-w-0 items-center gap-2', className)}
+      {...props}
+    >
+      <p className="truncate" title={label}>
+        {label}
+      </p>
+      {/*
+        A definite square rather than `h-full aspect-square w-fit`: a width
+        derived from a percentage height through an aspect ratio is not
+        transferred into the flex container's intrinsic width in Firefox, so
+        the image contributed 0 to the badge's max-content width and then took
+        that width back from the label at layout time.
+      */}
+      <div className="border-alpha-grey-300 size-10 shrink-0 overflow-hidden rounded-full border">
+        {image}
+      </div>
+    </div>
+  );
+}

--- a/src/common/presentation/ui/badge/badge.tsx
+++ b/src/common/presentation/ui/badge/badge.tsx
@@ -1,6 +1,8 @@
 import type { ComponentProps, ReactNode } from 'react';
 import { twMerge } from 'tailwind-merge';
 
+import { TruncatedText } from '@/ui/truncated-text/truncated-text';
+
 type BadgeProps = ComponentProps<'div'> & {
   label: string;
   image: ReactNode;
@@ -16,9 +18,7 @@ export function Badge({ label, image, className, ...props }: BadgeProps) {
       className={twMerge('flex min-w-0 items-center gap-2', className)}
       {...props}
     >
-      <p className="truncate" title={label}>
-        {label}
-      </p>
+      <TruncatedText text={label} />
       {/*
         A definite square rather than `h-full aspect-square w-fit`: a width
         derived from a percentage height through an aspect ratio is not

--- a/src/common/presentation/ui/date-expiration-status-icon/date-expiration-status-icon.tsx
+++ b/src/common/presentation/ui/date-expiration-status-icon/date-expiration-status-icon.tsx
@@ -27,7 +27,14 @@ export function DateExpirationStatusIcon({
       title={tooltip}
     >
       {displayLabel && <span className="text-nowrap">{statusLabel}</span>}
-      <Icon className={`${iconClassName} h-full w-full stroke-2 p-2`} />
+      {/*
+        A definite size rather than `h-full w-full`: the svg would otherwise
+        resolve a percentage against a box this component does not control, so
+        every caller had to hand it a height, and it collapsed to zero wherever
+        that height was itself indefinite (Firefox does not resolve percentage
+        heights against a table cell).
+      */}
+      <Icon className={`${iconClassName} size-10 shrink-0 stroke-2 p-2`} />
     </div>
   );
 }

--- a/src/common/presentation/ui/image/image.tsx
+++ b/src/common/presentation/ui/image/image.tsx
@@ -1,0 +1,32 @@
+import NextImage from 'next/image';
+import type { ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+type ImageWithFallbackProps = {
+  src?: string | null;
+  alt: string;
+  fallback: ReactNode;
+  className?: string;
+};
+
+/**
+ * Fills its container with `src`, or renders `fallback` when there is none.
+ * The container is the positioning context for the `fill` image, so it only
+ * carries `relative`; sizing is the caller's to state.
+ */
+export function ImageWithFallback({
+  src,
+  alt,
+  fallback,
+  className,
+}: ImageWithFallbackProps) {
+  return (
+    <div className={twMerge('relative', className)}>
+      {src ? (
+        <NextImage fill alt={alt} className="object-cover" src={src} />
+      ) : (
+        fallback
+      )}
+    </div>
+  );
+}

--- a/src/common/presentation/ui/table/cells/identifier/identifier.tsx
+++ b/src/common/presentation/ui/table/cells/identifier/identifier.tsx
@@ -1,0 +1,16 @@
+type TableIdentifierCellProps = {
+  value?: string | null;
+};
+
+/**
+ * Renders an opaque identifier (uuid, VIN, plate) on a single line with an
+ * ellipsis, and the full value in the tooltip. Pair it with `shouldSpan` on the
+ * column so the cell has a width range to clamp against.
+ */
+export function TableIdentifierCell({ value }: TableIdentifierCellProps) {
+  return (
+    <div className="line-clamp-1" title={value ?? undefined}>
+      {value}
+    </div>
+  );
+}

--- a/src/common/presentation/ui/table/compounds/body/body.tsx
+++ b/src/common/presentation/ui/table/compounds/body/body.tsx
@@ -1,5 +1,6 @@
 import { flexRender } from '@tanstack/react-table';
 import type { RefObject } from 'react';
+import { twMerge } from 'tailwind-merge';
 
 import { SearchIcon } from '@/icons/search';
 import { EmptyStatePlaceholder } from '@/ui/empty-state-placeholder/empty-state-placeholder';
@@ -41,7 +42,19 @@ export function TableBody({ lastRowRef }: TableBodyProps) {
           className="border-alpha-grey-200 hover:bg-alpha-grey-100 border-b last-of-type:border-0"
         >
           {row.getVisibleCells().map((cell) => (
-            <td key={cell.id} className="px-5 py-1 whitespace-nowrap">
+            <td
+              key={cell.id}
+              className={twMerge(
+                'px-5 py-1 whitespace-nowrap',
+                // `wrap-anywhere` rather than `break-all`: both drop
+                // min-content to a single character, which is what makes the
+                // column elastic, but `wrap-anywhere` only breaks mid-word
+                // when the line cannot fit. `min-w-28` puts a readable floor
+                // back under the shrinking.
+                cell.column.columnDef.meta?.shouldSpan &&
+                  'min-w-28 wrap-anywhere whitespace-normal',
+              )}
+            >
               {flexRender(cell.column.columnDef.cell, cell.getContext())}
             </td>
           ))}

--- a/src/common/presentation/ui/table/compounds/root/root.tsx
+++ b/src/common/presentation/ui/table/compounds/root/root.tsx
@@ -1,24 +1,26 @@
-import type { ComponentProps, ReactNode } from 'react';
+import type { ComponentProps } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import { useTable } from '../../table';
 
-type TableRootProps = ComponentProps<'table'> & {
+type TableRootProps = Omit<ComponentProps<'table'>, 'className'> & {
+  /**
+   * Applied to the scroll container wrapping the table, not to the table.
+   * Pass a height cap; the overflow is already handled.
+   */
   className?: string;
-  children?: ReactNode;
 };
 
 export function TableRoot({ className, children, ...props }: TableRootProps) {
   useTable();
 
   return (
-    // The wrapper is the table's scroll container, so callers pass only a
-    // height cap. Being a scroll container is also what lets it shrink: a flex
-    // or grid item whose overflow is not visible has an automatic minimum size
-    // of zero, so it escapes the min-content floor that `whitespace-nowrap`
-    // cells would otherwise impose.
+    // Being a scroll container is also what lets the wrapper shrink: a flex or
+    // grid item whose overflow is not visible has an automatic minimum size of
+    // zero, so it escapes the min-content floor that `whitespace-nowrap` cells
+    // would otherwise impose.
     <div className={twMerge('overflow-auto', className)}>
-      <table className="h-full w-full" {...props}>
+      <table className="w-full" {...props}>
         {children}
       </table>
     </div>

--- a/src/common/presentation/ui/table/compounds/root/root.tsx
+++ b/src/common/presentation/ui/table/compounds/root/root.tsx
@@ -1,4 +1,5 @@
 import type { ComponentProps, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
 
 import { useTable } from '../../table';
 
@@ -11,7 +12,12 @@ export function TableRoot({ className, children, ...props }: TableRootProps) {
   useTable();
 
   return (
-    <div className={className}>
+    // The wrapper is the table's scroll container, so callers pass only a
+    // height cap. Being a scroll container is also what lets it shrink: a flex
+    // or grid item whose overflow is not visible has an automatic minimum size
+    // of zero, so it escapes the min-content floor that `whitespace-nowrap`
+    // cells would otherwise impose.
+    <div className={twMerge('overflow-auto', className)}>
       <table className="h-full w-full" {...props}>
         {children}
       </table>

--- a/src/common/presentation/ui/truncated-text/truncated-text.test.tsx
+++ b/src/common/presentation/ui/truncated-text/truncated-text.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+
+import { TruncatedText } from './truncated-text';
+
+const MOCK_TEXT = 'a very long value that does not fit';
+
+describe('TruncatedText', () => {
+  it('should put the full text in the tooltip', () => {
+    render(<TruncatedText text={MOCK_TEXT} />);
+
+    expect(screen.getByText(MOCK_TEXT)).toHaveAttribute('title', MOCK_TEXT);
+  });
+
+  it('should render a numeric text and its tooltip', () => {
+    render(<TruncatedText text={0} />);
+
+    expect(screen.getByText('0')).toHaveAttribute('title', '0');
+  });
+
+  it('should render the fallback and no tooltip if there is no text', () => {
+    render(<TruncatedText fallback="---" text={null} />);
+
+    expect(screen.getByText('---')).not.toHaveAttribute('title');
+  });
+});

--- a/src/common/presentation/ui/truncated-text/truncated-text.tsx
+++ b/src/common/presentation/ui/truncated-text/truncated-text.tsx
@@ -1,0 +1,34 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+type TruncatedTextProps = ComponentProps<'p'> & {
+  text?: string | number | null;
+  fallback?: ReactNode;
+};
+
+/**
+ * Clamps `text` to one line with an ellipsis and puts the full value in the
+ * tooltip. Taking the text as a prop rather than as children is what keeps the
+ * two in sync: a `title` built at the call site has to spell out its own
+ * null handling, and `String(null)` is a tooltip reading "null".
+ *
+ * `truncate` implies `whitespace-nowrap`, which fixes min-content at the whole
+ * string. Cells of a `shouldSpan` column need the opposite and clamp with
+ * `line-clamp-1` instead; see `TableIdentifierCell`.
+ */
+export function TruncatedText({
+  text,
+  fallback,
+  className,
+  ...props
+}: TruncatedTextProps) {
+  return (
+    <p
+      className={twMerge('truncate', className)}
+      title={text?.toString()}
+      {...props}
+    >
+      {text ?? fallback}
+    </p>
+  );
+}

--- a/src/common/presentation/ui/variants/section.ts
+++ b/src/common/presentation/ui/variants/section.ts
@@ -1,4 +1,9 @@
-const baseClassName = 'p-4 text-sm w-full';
+// `min-w-0` because a section is always a layout participant, never the thing
+// that dictates layout width. Without it a section placed in a flex row or
+// grid track floors that track at its content's min-content width, which for
+// anything holding a table is a whole unbreakable row. Callers that do want a
+// floor state one (`min-w-xs`) and it wins over this.
+const baseClassName = 'p-4 text-sm w-full min-w-0';
 
 const defaultClassName = `${baseClassName} border rounded-md border-alpha-grey-200 bg-alpha-grey-50`;
 

--- a/src/module/car/ownership/presentation/ui/tables/ownerships/ownerships.tsx
+++ b/src/module/car/ownership/presentation/ui/tables/ownerships/ownerships.tsx
@@ -49,10 +49,7 @@ export function OwnershipsTable({
         <Table.TextFilter className="lg:w-fit" columnId="ownerId" />
       </div>
       <Table.SortBreadcrumb className="mt-5" />
-      <Table.Root
-        ref={tableRef}
-        className="my-4 max-h-96 overflow-auto lg:max-h-60"
-      >
+      <Table.Root ref={tableRef} className="my-4 max-h-96 lg:max-h-60">
         <caption className="sr-only">car ownerships</caption>
         <Table.Head />
         <Table.Body />

--- a/src/module/car/ownership/presentation/ui/tables/ownerships/use-ownerships.tsx
+++ b/src/module/car/ownership/presentation/ui/tables/ownerships/use-ownerships.tsx
@@ -28,7 +28,7 @@ const UserCell = memo(function UserCell({
   user: UserDto | undefined;
 }) {
   return user ? (
-    <UserBadge className="h-10 flex-row-reverse justify-end" user={user} />
+    <UserBadge className="flex-row-reverse justify-end" user={user} />
   ) : null;
 });
 

--- a/src/module/car/ownership/presentation/ui/tables/ownerships/use-ownerships.tsx
+++ b/src/module/car/ownership/presentation/ui/tables/ownerships/use-ownerships.tsx
@@ -5,6 +5,7 @@ import { memo, useMemo, useRef } from 'react';
 import type { OwnershipDto } from '@/car/ownership/application/dto/ownership';
 import { TableActionsDropdown } from '@/car/ownership/presentation/ui/tables/ownerships/actions-dropdown/actions-dropdown';
 import { KeyIcon } from '@/icons/key';
+import { TableIdentifierCell } from '@/ui/table/cells/identifier/identifier';
 import type { UserDto } from '@/user/application/dto/user';
 import { UserBadge } from '@/user/presentation/ui/badge/badge';
 
@@ -110,21 +111,8 @@ export function useOwnershipsTable({
           enableColumnFilter: true,
           filterFn: 'includesString',
           meta: { label: 'ID', shouldSpan: true },
-          // `break-all` is what makes the column elastic. An unbreakable word
-          // has the same min-content and max-content size, so auto table layout
-          // has no range to work with and the column can only ever be its full
-          // width. A break opportunity at every character drops min-content to
-          // one character while max-content stays the whole uuid, so the column
-          // grows and shrinks with the space available. `min-w-20` puts a
-          // readable floor back, and `line-clamp-1` keeps the result on one
-          // line with an ellipsis instead of wrapping.
           cell: ({ row }) => (
-            <div
-              className="line-clamp-1 min-w-20 break-all whitespace-normal"
-              title={row.original.ownerId}
-            >
-              {row.original.ownerId}
-            </div>
+            <TableIdentifierCell value={row.original.ownerId} />
           ),
         }),
         columnsHelper.display({

--- a/src/module/car/ownership/presentation/ui/tables/ownerships/use-ownerships.tsx
+++ b/src/module/car/ownership/presentation/ui/tables/ownerships/use-ownerships.tsx
@@ -110,6 +110,22 @@ export function useOwnershipsTable({
           enableColumnFilter: true,
           filterFn: 'includesString',
           meta: { label: 'ID', shouldSpan: true },
+          // `break-all` is what makes the column elastic. An unbreakable word
+          // has the same min-content and max-content size, so auto table layout
+          // has no range to work with and the column can only ever be its full
+          // width. A break opportunity at every character drops min-content to
+          // one character while max-content stays the whole uuid, so the column
+          // grows and shrinks with the space available. `min-w-20` puts a
+          // readable floor back, and `line-clamp-1` keeps the result on one
+          // line with an ellipsis instead of wrapping.
+          cell: ({ row }) => (
+            <div
+              className="line-clamp-1 min-w-20 break-all whitespace-normal"
+              title={row.original.ownerId}
+            >
+              {row.original.ownerId}
+            </div>
+          ),
         }),
         columnsHelper.display({
           id: 'actions',

--- a/src/module/car/presentation/ui/badge/badge.tsx
+++ b/src/module/car/presentation/ui/badge/badge.tsx
@@ -1,6 +1,5 @@
-import { twMerge } from 'tailwind-merge';
-
 import { CarImage } from '@/car/presentation/ui/image/image';
+import { Badge } from '@/ui/badge/badge';
 
 type CarBadgeProps = {
   name: string;
@@ -10,18 +9,10 @@ type CarBadgeProps = {
 
 export function CarBadge({ name, imageUrl, className }: CarBadgeProps) {
   return (
-    <div className={twMerge('flex min-w-0 items-center gap-2', className)}>
-      <p className="truncate">{name}</p>
-      {/*
-        Fixed square size rather than `h-full aspect-square w-fit`: a width
-        derived from a percentage height through an aspect ratio depends on the
-        caller giving this badge a definite height, and collapses in Firefox
-        wherever that height is a percentage or comes from a table cell.
-      */}
-      <CarImage
-        className="border-alpha-grey-300 size-10 shrink-0 overflow-hidden rounded-full border"
-        src={imageUrl}
-      />
-    </div>
+    <Badge
+      className={className}
+      image={<CarImage src={imageUrl} />}
+      label={name}
+    />
   );
 }

--- a/src/module/car/presentation/ui/badge/badge.tsx
+++ b/src/module/car/presentation/ui/badge/badge.tsx
@@ -10,15 +10,16 @@ type CarBadgeProps = {
 
 export function CarBadge({ name, imageUrl, className }: CarBadgeProps) {
   return (
-    <div
-      className={twMerge(
-        'flex flex-row items-center justify-center gap-2 overflow-auto',
-        className,
-      )}
-    >
+    <div className={twMerge('flex min-w-0 items-center gap-2', className)}>
       <p className="truncate">{name}</p>
+      {/*
+        Fixed square size rather than `h-full aspect-square w-fit`: a width
+        derived from a percentage height through an aspect ratio depends on the
+        caller giving this badge a definite height, and collapses in Firefox
+        wherever that height is a percentage or comes from a table cell.
+      */}
       <CarImage
-        className="border-alpha-grey-300 aspect-square h-full w-fit shrink-0 overflow-hidden rounded-full border"
+        className="border-alpha-grey-300 size-10 shrink-0 overflow-hidden rounded-full border"
         src={imageUrl}
       />
     </div>

--- a/src/module/car/presentation/ui/cards/details/data-field/data-field.tsx
+++ b/src/module/car/presentation/ui/cards/details/data-field/data-field.tsx
@@ -22,7 +22,7 @@ export function DetailsCardDataField({
         {Icon && (
           <Icon className="md:dark:stroke-accent-400/40 md:stroke-accent-500/50 hidden md:block md:h-7 md:w-7 md:shrink-0 md:stroke-3 md:p-0.5" />
         )}
-        <p className="overflow-auto">
+        <p className="truncate" title={value?.toString()}>
           {value ?? <span className="text-alpha-grey-900">---</span>}
         </p>
       </div>

--- a/src/module/car/presentation/ui/cards/details/data-field/data-field.tsx
+++ b/src/module/car/presentation/ui/cards/details/data-field/data-field.tsx
@@ -1,4 +1,5 @@
 import type { SvgA11yProps } from '@/ui/decorative/svg-a11y/svg-a11y';
+import { TruncatedText } from '@/ui/truncated-text/truncated-text';
 
 type DetailsCardDataFieldProps = {
   label: string;
@@ -22,9 +23,10 @@ export function DetailsCardDataField({
         {Icon && (
           <Icon className="md:dark:stroke-accent-400/40 md:stroke-accent-500/50 hidden md:block md:h-7 md:w-7 md:shrink-0 md:stroke-3 md:p-0.5" />
         )}
-        <p className="truncate" title={value?.toString()}>
-          {value ?? <span className="text-alpha-grey-900">---</span>}
-        </p>
+        <TruncatedText
+          fallback={<span className="text-alpha-grey-900">---</span>}
+          text={value}
+        />
       </div>
     </div>
   );

--- a/src/module/car/presentation/ui/cards/details/details.tsx
+++ b/src/module/car/presentation/ui/cards/details/details.tsx
@@ -60,7 +60,7 @@ export function DetailsCard({ car, className }: DetailsCardProps) {
         text="LEGAL & COMPLIANCE"
       />
 
-      <div className="flex flex-col gap-5">
+      <div className="mx-auto flex w-fit flex-col gap-5">
         <DetailsCardExpirationRow
           date={car?.insuranceExpiration}
           icon={CheckShieldIcon}

--- a/src/module/car/presentation/ui/cards/details/expiration-row/expiration-row.tsx
+++ b/src/module/car/presentation/ui/cards/details/expiration-row/expiration-row.tsx
@@ -38,7 +38,7 @@ export function DetailsCardExpirationRow({
       {date && (
         <DateExpirationStatusIcon
           displayLabel
-          className="ml-auto h-10 shrink-0 p-0.5 text-xs"
+          className="ml-auto shrink-0 text-xs"
           date={date}
           label={label}
         />

--- a/src/module/car/presentation/ui/cards/details/expiration-row/expiration-row.tsx
+++ b/src/module/car/presentation/ui/cards/details/expiration-row/expiration-row.tsx
@@ -1,5 +1,6 @@
 import { DateExpirationStatusIcon } from '@/ui/date-expiration-status-icon/date-expiration-status-icon';
 import type { SvgA11yProps } from '@/ui/decorative/svg-a11y/svg-a11y';
+import { TruncatedText } from '@/ui/truncated-text/truncated-text';
 
 type DetailsCardExpirationRowProps = {
   label: string;
@@ -12,13 +13,13 @@ export function DetailsCardExpirationRow({
   date,
   icon,
 }: DetailsCardExpirationRowProps) {
-  const formattedDate =
-    date &&
-    new Date(date).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
+  const formattedDate = date
+    ? new Date(date).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })
+    : null;
 
   const Icon = icon;
 
@@ -31,9 +32,10 @@ export function DetailsCardExpirationRow({
         <p className="text-alpha-grey-900 text-[10px]">
           {label.toUpperCase()} EXPIRATION
         </p>
-        <p className="truncate" title={formattedDate || undefined}>
-          {formattedDate ?? <span className="text-alpha-grey-900">---</span>}
-        </p>
+        <TruncatedText
+          fallback={<span className="text-alpha-grey-900">---</span>}
+          text={formattedDate}
+        />
       </div>
       {date && (
         <DateExpirationStatusIcon

--- a/src/module/car/presentation/ui/cards/details/expiration-row/expiration-row.tsx
+++ b/src/module/car/presentation/ui/cards/details/expiration-row/expiration-row.tsx
@@ -12,7 +12,7 @@ export function DetailsCardExpirationRow({
   date,
   icon,
 }: DetailsCardExpirationRowProps) {
-  const formatted =
+  const formattedDate =
     date &&
     new Date(date).toLocaleDateString('en-US', {
       month: 'short',
@@ -27,12 +27,12 @@ export function DetailsCardExpirationRow({
       {Icon && (
         <Icon className="md:dark:stroke-accent-400/40 md:stroke-accent-500/50 hidden md:block md:h-8 md:w-8 md:shrink-0 md:stroke-2" />
       )}
-      <div>
+      <div className="min-w-0">
         <p className="text-alpha-grey-900 text-[10px]">
           {label.toUpperCase()} EXPIRATION
         </p>
-        <p className="overflow-auto">
-          {formatted ?? <span className="text-alpha-grey-900">---</span>}
+        <p className="truncate" title={formattedDate || undefined}>
+          {formattedDate ?? <span className="text-alpha-grey-900">---</span>}
         </p>
       </div>
       {date && (

--- a/src/module/car/presentation/ui/cards/details/expiration-row/expiration-row.tsx
+++ b/src/module/car/presentation/ui/cards/details/expiration-row/expiration-row.tsx
@@ -23,7 +23,7 @@ export function DetailsCardExpirationRow({
   const Icon = icon;
 
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex items-center gap-5">
       {Icon && (
         <Icon className="md:dark:stroke-accent-400/40 md:stroke-accent-500/50 hidden md:block md:h-8 md:w-8 md:shrink-0 md:stroke-2" />
       )}

--- a/src/module/car/presentation/ui/cards/details/header/header.tsx
+++ b/src/module/car/presentation/ui/cards/details/header/header.tsx
@@ -18,15 +18,19 @@ export function DetailsCardHeader({ car }: DetailsCardHeaderProps) {
 
       <div className="flex w-full flex-col justify-evenly gap-1 self-stretch overflow-hidden">
         <DashboardSection.Heading
-          className="overflow-x-auto text-2xl leading-tight text-nowrap md:text-5xl"
+          className="truncate text-2xl leading-tight md:text-5xl"
           headingLevel="h1"
+          title={car?.customName}
           withUnderline={false}
         >
           {car?.customName}
         </DashboardSection.Heading>
 
         {car?.licensePlates && (
-          <p className="border-alpha-grey-200 bg-alpha-grey-50 max-w-fit overflow-x-auto rounded-sm border px-6 py-1 text-sm md:text-2xl">
+          <p
+            className="border-alpha-grey-200 bg-alpha-grey-50 w-fit max-w-full truncate rounded-sm border px-6 py-1 text-sm md:text-2xl"
+            title={car.licensePlates}
+          >
             {car.licensePlates}
           </p>
         )}
@@ -35,23 +39,28 @@ export function DetailsCardHeader({ car }: DetailsCardHeaderProps) {
           <div className="text-nowrap md:flex md:flex-col md:gap-3">
             <div className="flex items-center gap-3">
               <LabelIcon className="md:dark:stroke-accent-400/40 md:stroke-accent-500/50 hidden md:block md:h-7 md:w-7 md:stroke-2" />
-              <div>
+              <div className="min-w-0">
                 <p className="text-alpha-grey-900 hidden text-sm md:block">
                   BRAND
                 </p>
                 {car?.brand && (
-                  <p className="overflow-x-auto md:text-2xl">{car.brand}</p>
+                  <p className="truncate md:text-2xl" title={car.brand}>
+                    {car.brand}
+                  </p>
                 )}
               </div>
             </div>
             <div className="flex items-center gap-3">
               <SwatchIcon className="md:dark:stroke-accent-400/40 md:stroke-accent-500/50 hidden md:block md:h-7 md:w-7 md:stroke-2" />
-              <div>
+              <div className="min-w-0">
                 <p className="text-alpha-grey-900 hidden text-sm md:block">
                   MODEL
                 </p>
                 {car?.model && (
-                  <p className="text-alpha-grey-900 overflow-x-auto text-sm md:text-xl md:text-inherit">
+                  <p
+                    className="text-alpha-grey-900 truncate text-sm md:text-xl md:text-inherit"
+                    title={car.model}
+                  >
                     {car.model}
                   </p>
                 )}

--- a/src/module/car/presentation/ui/cards/details/header/header.tsx
+++ b/src/module/car/presentation/ui/cards/details/header/header.tsx
@@ -12,11 +12,11 @@ export function DetailsCardHeader({ car }: DetailsCardHeaderProps) {
   return (
     <div className="flex items-center gap-5 md:gap-10">
       <CarImage
-        className="w-4/12 overflow-hidden rounded-sm md:w-full md:max-w-64"
+        className="w-4/12 overflow-hidden rounded-sm"
         src={car?.imageUrl}
       />
 
-      <div className="flex max-w-8/12 flex-col justify-evenly gap-1 self-stretch">
+      <div className="flex w-full flex-col justify-evenly gap-1 self-stretch overflow-hidden">
         <DashboardSection.Heading
           className="overflow-x-auto text-2xl text-nowrap md:overflow-y-clip md:text-5xl"
           headingLevel="h1"

--- a/src/module/car/presentation/ui/cards/details/header/header.tsx
+++ b/src/module/car/presentation/ui/cards/details/header/header.tsx
@@ -18,7 +18,7 @@ export function DetailsCardHeader({ car }: DetailsCardHeaderProps) {
 
       <div className="flex w-full flex-col justify-evenly gap-1 self-stretch overflow-hidden">
         <DashboardSection.Heading
-          className="overflow-x-auto text-2xl text-nowrap md:overflow-y-clip md:text-5xl"
+          className="overflow-x-auto text-2xl leading-tight text-nowrap md:text-5xl"
           headingLevel="h1"
           withUnderline={false}
         >

--- a/src/module/car/presentation/ui/cards/details/header/header.tsx
+++ b/src/module/car/presentation/ui/cards/details/header/header.tsx
@@ -3,6 +3,7 @@ import { CarImage } from '@/car/presentation/ui/image/image';
 import { DashboardSection } from '@/dashboard/ui/section/section';
 import { LabelIcon } from '@/icons/label';
 import { SwatchIcon } from '@/icons/swatch';
+import { TruncatedText } from '@/ui/truncated-text/truncated-text';
 
 type DetailsCardHeaderProps = {
   car?: CarDto;
@@ -27,12 +28,10 @@ export function DetailsCardHeader({ car }: DetailsCardHeaderProps) {
         </DashboardSection.Heading>
 
         {car?.licensePlates && (
-          <p
-            className="border-alpha-grey-200 bg-alpha-grey-50 w-fit max-w-full truncate rounded-sm border px-6 py-1 text-sm md:text-2xl"
-            title={car.licensePlates}
-          >
-            {car.licensePlates}
-          </p>
+          <TruncatedText
+            className="border-alpha-grey-200 bg-alpha-grey-50 w-fit max-w-full rounded-sm border px-6 py-1 text-sm md:text-2xl"
+            text={car.licensePlates}
+          />
         )}
 
         {(car?.brand || car?.model) && (
@@ -44,9 +43,7 @@ export function DetailsCardHeader({ car }: DetailsCardHeaderProps) {
                   BRAND
                 </p>
                 {car?.brand && (
-                  <p className="truncate md:text-2xl" title={car.brand}>
-                    {car.brand}
-                  </p>
+                  <TruncatedText className="md:text-2xl" text={car.brand} />
                 )}
               </div>
             </div>
@@ -57,12 +54,10 @@ export function DetailsCardHeader({ car }: DetailsCardHeaderProps) {
                   MODEL
                 </p>
                 {car?.model && (
-                  <p
-                    className="text-alpha-grey-900 truncate text-sm md:text-xl md:text-inherit"
-                    title={car.model}
-                  >
-                    {car.model}
-                  </p>
+                  <TruncatedText
+                    className="text-alpha-grey-900 text-sm md:text-xl md:text-inherit"
+                    text={car.model}
+                  />
                 )}
               </div>
             </div>

--- a/src/module/car/presentation/ui/image/image.tsx
+++ b/src/module/car/presentation/ui/image/image.tsx
@@ -1,7 +1,7 @@
-import NextImage from 'next/image';
 import { twMerge } from 'tailwind-merge';
 
 import { BrandFullIcon } from '@/icons/brand-full';
+import { ImageWithFallback } from '@/ui/image/image';
 
 type CarImageProps = {
   src?: string | null;
@@ -10,19 +10,16 @@ type CarImageProps = {
 
 export function CarImage({ src, className }: CarImageProps) {
   return (
-    <div
+    <ImageWithFallback
+      alt="car image"
       className={twMerge(
-        'relative flex aspect-square w-full items-center justify-center',
+        'flex aspect-square w-full items-center justify-center',
         className,
       )}
-    >
-      {src && (
-        <NextImage fill alt="car image" className="object-cover" src={src} />
-      )}
-
-      {!src && (
-        <BrandFullIcon className="stroke-alpha-grey-600 stroke-[0.1] object-cover" />
-      )}
-    </div>
+      fallback={
+        <BrandFullIcon className="stroke-alpha-grey-600 stroke-[0.1]" />
+      }
+      src={src}
+    />
   );
 }

--- a/src/module/car/presentation/ui/tables/date-expiration/date-expiration.tsx
+++ b/src/module/car/presentation/ui/tables/date-expiration/date-expiration.tsx
@@ -31,7 +31,7 @@ export function DateExpirationTable({
   return (
     <Table columns={columns} data={data}>
       <div className="flex grow flex-col justify-between">
-        <Table.Root className="max-h-96 overflow-y-auto lg:max-h-80">
+        <Table.Root className="max-h-96 lg:max-h-80">
           <Table.Head className="h-12" />
           <Table.Body lastRowRef={intersectionTargetRef} />
         </Table.Root>

--- a/src/module/car/presentation/ui/tables/date-expiration/use-date-expiration.tsx
+++ b/src/module/car/presentation/ui/tables/date-expiration/use-date-expiration.tsx
@@ -38,9 +38,12 @@ export function useDateExpirationTable({
           id: 'status',
           cell: ({ row }) => {
             const date = row.original[dateColumn];
+            // Definite size rather than `aspect-square h-full`: Firefox does
+            // not resolve percentage heights against a table cell, so the icon
+            // and the svg it sizes both collapsed to zero.
             return date ? (
               <DateExpirationStatusIcon
-                className="aspect-square h-full p-0.5"
+                className="size-10 p-0.5"
                 date={date}
                 label={label}
               />

--- a/src/module/car/presentation/ui/tables/date-expiration/use-date-expiration.tsx
+++ b/src/module/car/presentation/ui/tables/date-expiration/use-date-expiration.tsx
@@ -13,6 +13,7 @@ import { useInfiniteScrollTrigger } from '@/common/presentation/hook/use-infinit
 import { useToasts } from '@/common/presentation/hook/use-toasts';
 import { queryKeySerialize } from '@/common/presentation/tanstack/query-key-serialize';
 import { DateExpirationStatusIcon } from '@/ui/date-expiration-status-icon/date-expiration-status-icon';
+import { TableIdentifierCell } from '@/ui/table/cells/identifier/identifier';
 
 const columnsHelper = createColumnHelper<CarDto>();
 
@@ -67,22 +68,7 @@ export function useDateExpirationTable({
         }),
         columnsHelper.accessor('vin', {
           meta: { label: 'VIN', shouldSpan: true },
-          // `break-all` is what makes the column elastic. An unbreakable word
-          // has the same min-content and max-content size, so auto table layout
-          // has no range to work with and the column can only ever be its full
-          // width. A break opportunity at every character drops min-content to
-          // one character while max-content stays the whole value, so the
-          // column grows and shrinks with the space available. `min-w-20` puts
-          // a readable floor back, and `line-clamp-1` keeps the result on one
-          // line with an ellipsis instead of wrapping.
-          cell: ({ row }) => (
-            <div
-              className="line-clamp-1 min-w-20 break-all whitespace-normal"
-              title={row.original.vin ?? ''}
-            >
-              {row.original.vin}
-            </div>
-          ),
+          cell: ({ row }) => <TableIdentifierCell value={row.original.vin} />,
         }),
         columnsHelper.display({
           id: 'actions',

--- a/src/module/car/presentation/ui/tables/date-expiration/use-date-expiration.tsx
+++ b/src/module/car/presentation/ui/tables/date-expiration/use-date-expiration.tsx
@@ -38,15 +38,8 @@ export function useDateExpirationTable({
           id: 'status',
           cell: ({ row }) => {
             const date = row.original[dateColumn];
-            // Definite size rather than `aspect-square h-full`: Firefox does
-            // not resolve percentage heights against a table cell, so the icon
-            // and the svg it sizes both collapsed to zero.
             return date ? (
-              <DateExpirationStatusIcon
-                className="size-10 p-0.5"
-                date={date}
-                label={label}
-              />
+              <DateExpirationStatusIcon date={date} label={label} />
             ) : null;
           },
         }),

--- a/src/module/car/presentation/ui/tables/date-expiration/use-date-expiration.tsx
+++ b/src/module/car/presentation/ui/tables/date-expiration/use-date-expiration.tsx
@@ -74,6 +74,22 @@ export function useDateExpirationTable({
         }),
         columnsHelper.accessor('vin', {
           meta: { label: 'VIN', shouldSpan: true },
+          // `break-all` is what makes the column elastic. An unbreakable word
+          // has the same min-content and max-content size, so auto table layout
+          // has no range to work with and the column can only ever be its full
+          // width. A break opportunity at every character drops min-content to
+          // one character while max-content stays the whole value, so the
+          // column grows and shrinks with the space available. `min-w-20` puts
+          // a readable floor back, and `line-clamp-1` keeps the result on one
+          // line with an ellipsis instead of wrapping.
+          cell: ({ row }) => (
+            <div
+              className="line-clamp-1 min-w-20 break-all whitespace-normal"
+              title={row.original.vin ?? ''}
+            >
+              {row.original.vin}
+            </div>
+          ),
         }),
         columnsHelper.display({
           id: 'actions',

--- a/src/module/car/presentation/ui/tables/date-expiration/use-date-expiration.tsx
+++ b/src/module/car/presentation/ui/tables/date-expiration/use-date-expiration.tsx
@@ -61,7 +61,7 @@ export function useDateExpirationTable({
             return (
               <div className="max-w-32">
                 <CarBadge
-                  className="h-10 flex-row-reverse justify-end"
+                  className="flex-row-reverse justify-end"
                   imageUrl={imageUrl}
                   name={customName}
                 />

--- a/src/module/car/service-log/presentation/ui/sections/service-logs/service-logs.tsx
+++ b/src/module/car/service-log/presentation/ui/sections/service-logs/service-logs.tsx
@@ -60,7 +60,7 @@ export function ServiceLogsSection({
         Service Logs
       </DashboardSection.Heading>
       <ServiceLogsTable
-        className="my-5 max-h-96 scrollbar-gutter-stable overflow-auto"
+        className="my-5 max-h-96 scrollbar-gutter-stable"
         isSessionUserPrimaryOwner={isSessionUserPrimaryOwner}
         serviceLogs={serviceLogs}
         sessionUserId={sessionUserId}

--- a/src/module/car/service-log/presentation/ui/tables/service-logs/service-logs.tsx
+++ b/src/module/car/service-log/presentation/ui/tables/service-logs/service-logs.tsx
@@ -18,7 +18,7 @@ export function ServiceLogsTable({
   users,
   isSessionUserPrimaryOwner,
   sessionUserId,
-  className = '',
+  className,
 }: ServiceLogsTableProps) {
   const { data, columns, tableRef } = useServiceLogsTable({
     serviceLogs,

--- a/src/module/car/service-log/presentation/ui/tables/service-logs/use-service-logs.tsx
+++ b/src/module/car/service-log/presentation/ui/tables/service-logs/use-service-logs.tsx
@@ -47,11 +47,7 @@ const NotesCell = memo(function NotesCell({
 }: {
   notes: ServiceLogDto['notes'];
 }) {
-  return (
-    <div className="max-h-24 w-52 overflow-y-auto text-wrap lg:w-fit">
-      {notes}
-    </div>
-  );
+  return <div className="max-h-24 overflow-y-auto">{notes}</div>;
 });
 
 const CreatorCell = memo(function CreatorCell({

--- a/src/module/car/service-log/presentation/ui/tables/service-logs/use-service-logs.tsx
+++ b/src/module/car/service-log/presentation/ui/tables/service-logs/use-service-logs.tsx
@@ -60,7 +60,7 @@ const CreatorCell = memo(function CreatorCell({
   user: UserDto | undefined;
 }) {
   return user ? (
-    <UserBadge className="h-10 flex-row-reverse justify-end" user={user} />
+    <UserBadge className="flex-row-reverse justify-end" user={user} />
   ) : null;
 });
 

--- a/src/module/car/service-log/presentation/ui/tables/service-logs/use-service-logs.tsx
+++ b/src/module/car/service-log/presentation/ui/tables/service-logs/use-service-logs.tsx
@@ -7,6 +7,7 @@ import { serviceCategoryLabelValueMapping } from '@/car/service-log/interface/ui
 import { TableActionsDropdown } from '@/car/service-log/presentation/ui/tables/service-logs/actions-dropdown/actions-dropdown';
 import { filterColumnByDate } from '@/ui/table/compounds/date-filter/filter-column-by-date';
 import { Tag } from '@/ui/tag/tag';
+import { TruncatedText } from '@/ui/truncated-text/truncated-text';
 import type { UserDto } from '@/user/application/dto/user';
 import { UserBadge } from '@/user/presentation/ui/badge/badge';
 
@@ -22,30 +23,6 @@ const CategoryCell = memo(function CategoryCell({
       {categories.map((category) => (
         <Tag key={category}>{category}</Tag>
       ))}
-    </div>
-  );
-});
-
-const MileageCell = memo(function MileageCell({
-  mileage,
-}: {
-  mileage: ServiceLogDto['mileage'];
-}) {
-  return (
-    <div className="max-w-32 truncate" title={String(mileage)}>
-      {mileage}
-    </div>
-  );
-});
-
-const CostCell = memo(function CostCell({
-  cost,
-}: {
-  cost: ServiceLogDto['serviceCost'];
-}) {
-  return (
-    <div className="max-w-32 truncate" title={String(cost)}>
-      {cost}
     </div>
   );
 });
@@ -144,12 +121,19 @@ export function useServiceLogsTable({
         columnsHelper.accessor('mileage', {
           meta: { label: 'Mileage' },
           enableSorting: true,
-          cell: ({ row }) => <MileageCell mileage={row.original.mileage} />,
+          cell: ({ row }) => (
+            <TruncatedText className="max-w-32" text={row.original.mileage} />
+          ),
         }),
         columnsHelper.accessor('serviceCost', {
           meta: { label: 'Cost' },
           enableSorting: true,
-          cell: ({ row }) => <CostCell cost={row.original.serviceCost} />,
+          cell: ({ row }) => (
+            <TruncatedText
+              className="max-w-32"
+              text={row.original.serviceCost}
+            />
+          ),
         }),
         columnsHelper.accessor('notes', {
           meta: { label: 'Notes', shouldSpan: true },

--- a/src/module/car/service-log/presentation/ui/tables/service-logs/use-service-logs.tsx
+++ b/src/module/car/service-log/presentation/ui/tables/service-logs/use-service-logs.tsx
@@ -31,7 +31,11 @@ const MileageCell = memo(function MileageCell({
 }: {
   mileage: ServiceLogDto['mileage'];
 }) {
-  return <div className="max-w-32 overflow-x-auto">{mileage}</div>;
+  return (
+    <div className="max-w-32 truncate" title={String(mileage)}>
+      {mileage}
+    </div>
+  );
 });
 
 const CostCell = memo(function CostCell({
@@ -39,7 +43,11 @@ const CostCell = memo(function CostCell({
 }: {
   cost: ServiceLogDto['serviceCost'];
 }) {
-  return <div className="max-w-32 overflow-x-auto">{cost}</div>;
+  return (
+    <div className="max-w-32 truncate" title={String(cost)}>
+      {cost}
+    </div>
+  );
 });
 
 const NotesCell = memo(function NotesCell({

--- a/src/module/car/service-log/presentation/ui/tables/service-logs/use-service-logs.tsx
+++ b/src/module/car/service-log/presentation/ui/tables/service-logs/use-service-logs.tsx
@@ -55,7 +55,10 @@ const NotesCell = memo(function NotesCell({
 }: {
   notes: ServiceLogDto['notes'];
 }) {
-  return <div className="max-h-24 overflow-y-auto">{notes}</div>;
+  // A wider floor than the one the spanning column gives every cell: prose
+  // needs more characters per line than an identifier does before it stops
+  // being readable, and this cell caps its height rather than its line count.
+  return <div className="max-h-24 min-w-52 overflow-y-auto">{notes}</div>;
 });
 
 const CreatorCell = memo(function CreatorCell({

--- a/src/module/dashboard/ui/main/main.tsx
+++ b/src/module/dashboard/ui/main/main.tsx
@@ -10,7 +10,11 @@ export function DashboardMain({ children, className }: DashboardMainProps) {
   return (
     <main
       className={twMerge(
-        'flex min-h-screen max-w-screen items-center justify-center pt-16 md:pl-16',
+        // `max-w-full` rather than `max-w-screen`: `100vw` counts the classic
+        // scrollbar, so it exceeds the content box by the gutter width.
+        // Safe centering so that content wider than the viewport overflows the
+        // end edge only, where it stays reachable by scrolling.
+        'flex min-h-screen max-w-full items-center-safe justify-center-safe pt-16 md:pl-16',
         className,
       )}
     >

--- a/src/module/dashboard/ui/sections/overview/overview.tsx
+++ b/src/module/dashboard/ui/sections/overview/overview.tsx
@@ -12,11 +12,19 @@ export function OverviewSection() {
       variant="raw"
     >
       <SectionHeading headingLevel="h1">Overview</SectionHeading>
-      <div className="lg:mx-auto lg:flex lg:w-full lg:max-w-7xl lg:grow lg:items-center lg:justify-center">
-        <div className="flex flex-col gap-5 lg:grid lg:w-full lg:grid-cols-[auto_1fr_auto]">
+      <div className="lg:mx-auto lg:flex lg:w-full lg:max-w-7xl lg:grow lg:items-center lg:justify-center-safe">
+        {/*
+          `min-w-0` because this is a flex item of the row above: a flex item's
+          automatic minimum size floors it at its content's min-content width,
+          which for `whitespace-nowrap` table cells is a whole table row. That
+          floor would push the grid past the viewport instead of letting the
+          tables scroll. The sections inside carry the same, from
+          `sectionVariants`, since grid items get the floor too.
+        */}
+        <div className="flex min-w-0 flex-col gap-5 lg:grid lg:w-full lg:grid-cols-[auto_1fr_auto]">
           <TotalOwnershipsSection className="lg:col-span-1 lg:min-w-xs" />
           <InsuranceExpirationSection className="lg:col-span-2" />
-          <TechnicalInspectionExpirationSection className="lg:col-span-2 lg:min-w-fit" />
+          <TechnicalInspectionExpirationSection className="lg:col-span-2" />
           <CostsSection className="lg:col-span-1 lg:max-w-md" />
         </div>
       </div>

--- a/src/module/user/presentation/ui/badge/badge.tsx
+++ b/src/module/user/presentation/ui/badge/badge.tsx
@@ -20,7 +20,7 @@ export function UserBadge({ user, className }: UserBadgeProps) {
       )}
       data-testid={USER_BADGE_TEST_ID}
     >
-      <p className="overflow-auto">{user.name}</p>
+      <p className="truncate overflow-auto">{user.name}</p>
       <UserImage
         className="border-alpha-grey-300 aspect-square h-full w-fit shrink-0 overflow-hidden rounded-full border"
         src={user.avatarUrl}

--- a/src/module/user/presentation/ui/badge/badge.tsx
+++ b/src/module/user/presentation/ui/badge/badge.tsx
@@ -1,5 +1,4 @@
-import { twMerge } from 'tailwind-merge';
-
+import { Badge } from '@/ui/badge/badge';
 import type { UserDto } from '@/user/application/dto/user';
 
 import { UserImage } from '../image/image';
@@ -13,23 +12,11 @@ type UserBadgeProps = {
 
 export function UserBadge({ user, className }: UserBadgeProps) {
   return (
-    <div
-      className={twMerge('flex min-w-0 items-center gap-2', className)}
+    <Badge
+      className={className}
       data-testid={USER_BADGE_TEST_ID}
-    >
-      <p className="min-w-0 overflow-x-auto whitespace-nowrap">{user.name}</p>
-      {/*
-        Fixed square size rather than `h-full aspect-square w-fit`: a width
-        derived from a percentage height through an aspect ratio is not
-        transferred into the flex container's intrinsic width in Firefox, so
-        the avatar contributed 0 to the badge's max-content width and then ate
-        that width back from the name at layout time (scrollbar on a name that
-        fits).
-      */}
-      <UserImage
-        className="border-alpha-grey-300 size-12 shrink-0 overflow-hidden rounded-full border"
-        src={user.avatarUrl}
-      />
-    </div>
+      image={<UserImage src={user.avatarUrl} />}
+      label={user.name}
+    />
   );
 }

--- a/src/module/user/presentation/ui/badge/badge.tsx
+++ b/src/module/user/presentation/ui/badge/badge.tsx
@@ -14,15 +14,20 @@ type UserBadgeProps = {
 export function UserBadge({ user, className }: UserBadgeProps) {
   return (
     <div
-      className={twMerge(
-        'flex flex-row items-center justify-center gap-2 overflow-auto',
-        className,
-      )}
+      className={twMerge('flex min-w-0 items-center gap-2', className)}
       data-testid={USER_BADGE_TEST_ID}
     >
-      <p className="truncate overflow-auto">{user.name}</p>
+      <p className="min-w-0 overflow-x-auto whitespace-nowrap">{user.name}</p>
+      {/*
+        Fixed square size rather than `h-full aspect-square w-fit`: a width
+        derived from a percentage height through an aspect ratio is not
+        transferred into the flex container's intrinsic width in Firefox, so
+        the avatar contributed 0 to the badge's max-content width and then ate
+        that width back from the name at layout time (scrollbar on a name that
+        fits).
+      */}
       <UserImage
-        className="border-alpha-grey-300 aspect-square h-full w-fit shrink-0 overflow-hidden rounded-full border"
+        className="border-alpha-grey-300 size-12 shrink-0 overflow-hidden rounded-full border"
         src={user.avatarUrl}
       />
     </div>

--- a/src/module/user/presentation/ui/image/image.tsx
+++ b/src/module/user/presentation/ui/image/image.tsx
@@ -1,7 +1,7 @@
-import Image from 'next/image';
 import { twMerge } from 'tailwind-merge';
 
 import { UserIcon } from '@/icons/user';
+import { ImageWithFallback } from '@/ui/image/image';
 
 type UserImageProps = {
   src?: string | null;
@@ -10,12 +10,13 @@ type UserImageProps = {
 
 export function UserImage({ src, className }: UserImageProps) {
   return (
-    <div className={twMerge('relative h-full w-full', className)}>
-      {src && (
-        <Image fill alt="avatar image" className="object-cover" src={src} />
-      )}
-
-      {!src && <UserIcon className="stroke-alpha-grey-600 object-cover p-2" />}
-    </div>
+    <ImageWithFallback
+      alt="avatar image"
+      className={twMerge('h-full w-full', className)}
+      fallback={
+        <UserIcon className="stroke-alpha-grey-600 h-full w-full p-2" />
+      }
+      src={src}
+    />
   );
 }

--- a/src/module/user/presentation/ui/image/image.tsx
+++ b/src/module/user/presentation/ui/image/image.tsx
@@ -10,21 +10,12 @@ type UserImageProps = {
 
 export function UserImage({ src, className }: UserImageProps) {
   return (
-    <div
-      className={twMerge(
-        'relative flex h-full w-full items-center justify-center',
-        className,
-      )}
-    >
+    <div className={twMerge('relative h-full w-full', className)}>
       {src && (
         <Image fill alt="avatar image" className="object-cover" src={src} />
       )}
 
-      {!src && (
-        <div className="h-full w-full py-2">
-          <UserIcon className="stroke-alpha-grey-600 h-full w-full object-cover" />
-        </div>
-      )}
+      {!src && <UserIcon className="stroke-alpha-grey-600 object-cover p-2" />}
     </div>
   );
 }

--- a/src/types/tanstack-table.d.ts
+++ b/src/types/tanstack-table.d.ts
@@ -5,6 +5,14 @@ import type { ColumnSort } from '@tanstack/react-table';
 declare module '@tanstack/react-table' {
   interface ColumnMeta<TData extends RowData, TValue> {
     label: string;
+    /**
+     * Marks the column that absorbs the table's leftover width. The head gives
+     * it `w-auto` against the `w-1` every other column gets, and the body lets
+     * its content break anywhere so the column can give width back too: a
+     * value with no break opportunity has the same min-content and max-content
+     * size, so auto table layout has no range to work with and the column is
+     * stuck at its full width.
+     */
     shouldSpan?: boolean;
     filter?:
       | {


### PR DESCRIPTION
## Summary
- Fix overflow and scrolling bugs throughout the app: tables, sections, the dashboard grid, and avatar/icon sizing no longer get squeezed or pushed off-screen by their flex containers.
- Add a `TruncatedText` component that shows one line of text with the full value in a tooltip, and use it in table cells, the car details card, and badge labels instead of ad hoc scrolling or clipping.
- Extract shared `Badge` and `ImageWithFallback` components, replacing the near-duplicate car/user variants that had drifted on overflow handling and sizing.
- Move the table's elastic "spanning column" sizing out of per-table hooks and into the shared table body, replacing `break-all` with `wrap-anywhere` so words only break mid-word when a line can't otherwise fit.
- Fix two null-handling bugs: empty mileage/cost cells showed a tooltip reading "null", and a blank expiration date rendered as an empty line instead of the placeholder.

## Why
Mostly bug fixes for overflow/scrolling regressions, plus cleanup of car/user duplication that had drifted apart over time.

## Key points
- `TruncatedText` takes its text as a prop rather than children, so the tooltip and the rendered value can't diverge (a title built at the call site would have to reimplement null handling).
- The spanning column's break behavior now lives once in the shared table body (`shouldSpan` metadata), instead of being copy-pasted into each table's hook.