### PR TITLE
refactor(dropdown): portal the panel and manage its focus explicitly

### DIFF
--- a/src/common/presentation/ui/dropdown/compounds/content/content.tsx
+++ b/src/common/presentation/ui/dropdown/compounds/content/content.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 
 import type { UseDropdownContentParams } from './use-content';
 import { useDropdownContent } from './use-content';
@@ -13,31 +14,41 @@ export function DropdownContent({
   align,
   children,
 }: DropdownContentProps) {
-  const { isOpen, position, contentRef, contentId } = useDropdownContent({
-    collisionDetection,
-    side,
-    align,
-  });
+  const { isOpen, position, contentRef, contentId, handleKeyDown } =
+    useDropdownContent({
+      collisionDetection,
+      side,
+      align,
+    });
 
   if (!isOpen) return null;
 
-  //! `fixed` below resolves against the viewport, which is what
-  //! useDropdownContent measures its coordinates against. That holds only while
-  //! no ancestor establishes a containing block. A transform, filter,
-  //! backdrop-filter, contain, or container-type anywhere above this panel makes
-  //! `fixed` resolve against that ancestor instead, so the panel lands offset and
-  //! is clipped by any overflow between the two, with nothing pointing at the
-  //! cause. The sticky table header is opaque rather than backdrop-blurred for
-  //! exactly this reason, and no dropdown is rendered inside a Card, whose
-  //! drop-shadow is a filter.
-  return (
+  //! The portal is what keeps `fixed` below resolving against the viewport,
+  //! which is what useDropdownContent measures its coordinates against.
+  //! Otherwise `fixed` resolves against the nearest ancestor establishing a
+  //! containing block, and a transform, filter, backdrop-filter, contain, or
+  //! container-type is enough to establish one. Rendered inline, this panel
+  //! would land offset and be clipped by any overflow in between the moment
+  //! the dashboard's main region became a query container, with nothing in the
+  //! failure pointing at the cause.
+  return createPortal(
+    /* eslint-disable-next-line jsx-a11y/no-static-element-interactions --
+       the panel is not interactive and takes no role. The handler only sends
+       focus back to the trigger when Tab is about to carry it off either end,
+       which is keyboard support rather than an interaction of its own. */
     <div
       ref={contentRef}
       className="bg-light-500 dark:bg-dark-500 border-alpha-grey-500 fixed z-60 rounded-lg border p-1"
       id={contentId}
       style={{ top: position.top, left: position.left }}
+      // Focused on open, so it has to be able to hold focus. It stays out of
+      // the sequential tab order: the panel is the last node in the document,
+      // and tabbing into it from there would read as a jump backwards.
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
     >
       {children}
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/common/presentation/ui/dropdown/compounds/content/content.tsx
+++ b/src/common/presentation/ui/dropdown/compounds/content/content.tsx
@@ -33,7 +33,7 @@ export function DropdownContent({
   return (
     <div
       ref={contentRef}
-      className="bg-light-500 dark:bg-dark-500 border-alpha-grey-500 fixed z-20 rounded-lg border p-1"
+      className="bg-light-500 dark:bg-dark-500 border-alpha-grey-500 fixed z-60 rounded-lg border p-1"
       id={contentId}
       style={{ top: position.top, left: position.left }}
     >

--- a/src/common/presentation/ui/dropdown/compounds/content/use-content.test.ts
+++ b/src/common/presentation/ui/dropdown/compounds/content/use-content.test.ts
@@ -9,6 +9,7 @@ jest.mock('../../dropdown', () => ({
 
 const mockUseDropdown = useDropdown as jest.Mock;
 const mockTriggerRef: { current: HTMLButtonElement | null } = { current: null };
+const mockContentRef: { current: HTMLDivElement | null } = { current: null };
 
 function makeFakeElement(rect: {
   top?: number;
@@ -48,6 +49,7 @@ function setupMockContext(
   mockUseDropdown.mockReturnValue({
     isOpen: overrides.isOpen ?? false,
     triggerRef: mockTriggerRef,
+    contentRef: mockContentRef,
     collisionDetectionRoot: overrides.collisionDetectionRoot ?? null,
   });
 }
@@ -81,6 +83,7 @@ function renderAndOpen(
 beforeEach(() => {
   jest.clearAllMocks();
   mockTriggerRef.current = null;
+  mockContentRef.current = null;
 
   Object.defineProperty(window, 'innerWidth', {
     value: 1000,

--- a/src/common/presentation/ui/dropdown/compounds/content/use-content.ts
+++ b/src/common/presentation/ui/dropdown/compounds/content/use-content.ts
@@ -1,10 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 
 import { useDropdown } from '../../dropdown';
 
@@ -242,9 +236,10 @@ export function useDropdownContent({
   align = 'start',
 }: UseDropdownContentParams) {
   const [position, setPosition] = useState({ top: 0, left: 0 });
-  const contentRef = useRef<HTMLDivElement>(null);
 
-  const { isOpen, triggerRef, collisionDetectionRoot, contentId } =
+  // Owned by the Dropdown context because the dismissal listeners need it to
+  // decide whether an event landed inside the panel.
+  const { isOpen, triggerRef, contentRef, collisionDetectionRoot, contentId } =
     useDropdown();
 
   const computePosition = useCallback((): { top: number; left: number } => {
@@ -279,7 +274,14 @@ export function useDropdownContent({
     const effectiveAlign = resolveEffectiveAlign(align, alignCollisions);
 
     return calculatePanelPosition(dimensions, effectiveSide, effectiveAlign);
-  }, [triggerRef, collisionDetection, collisionDetectionRoot, side, align]);
+  }, [
+    triggerRef,
+    contentRef,
+    collisionDetection,
+    collisionDetectionRoot,
+    side,
+    align,
+  ]);
 
   const updatePosition = useCallback(() => {
     setPosition(computePosition());

--- a/src/common/presentation/ui/dropdown/compounds/content/use-content.ts
+++ b/src/common/presentation/ui/dropdown/compounds/content/use-content.ts
@@ -1,6 +1,27 @@
+import type { KeyboardEvent } from 'react';
 import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 
 import { useDropdown } from '../../dropdown';
+
+/**
+ * Everything inside `root` that Tab can reach, in document order. Used to find
+ * the two ends of the panel's own tab order, not to trap focus between them.
+ *
+ * Both conditions are the platform's own answer rather than a restatement of
+ * it. `tabIndex` falls back to the element type's default when the attribute is
+ * absent, which is 0 for a focusable area and -1 for everything else, so an
+ * explicit `tabindex="-1"` on an otherwise focusable control is excluded.
+ * `:disabled` carries the `fieldset` inheritance a `[disabled]` selector cannot
+ * see. Enumerating tag names instead would restate both, and get both wrong.
+ *
+ * Visibility is not checked: every panel in the app renders its controls
+ * conditionally rather than hiding them.
+ */
+function findFocusable(root: HTMLElement): HTMLElement[] {
+  return [...root.querySelectorAll<HTMLElement>('*')].filter(
+    (element) => element.tabIndex >= 0 && !element.matches(':disabled'),
+  );
+}
 
 /**
  * Which side of the trigger the panel should prefer to open on.
@@ -294,6 +315,51 @@ export function useDropdownContent({
     updatePosition();
   }, [isOpen, updatePosition]);
 
+  // The panel is portaled out of the trigger's subtree, so DOM order no longer
+  // carries the keyboard from one to the other. Focus lands on the container
+  // rather than on the first control: one panel leads with a text filter, and
+  // landing there would make the same gesture type a character in one dropdown
+  // and activate a button in another.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    contentRef.current?.focus();
+  }, [isOpen, contentRef]);
+
+  /**
+   * Sends focus back to the trigger when Tab would carry it off either end of
+   * the panel.
+   *
+   * The default action is deliberately left to run: the browser resolves the
+   * next tab stop against whatever holds focus once the handler returns, so
+   * moving focus to the trigger first is what makes the page continue tabbing
+   * from the trigger's place in document order rather than from the end of the
+   * body. The panel then closes behind the user through the focus-out listener
+   * on the document.
+   */
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== 'Tab') return;
+
+      const panel = contentRef.current;
+
+      if (!panel) return;
+
+      const focusable = findFocusable(panel);
+
+      // Backwards counts the panel itself as a boundary as well as its first
+      // control: the container holds focus on open, and its tabindex of -1
+      // keeps it out of the sequential order, so a Shift+Tab from the first
+      // control skips past it and leaves the panel too.
+      const isLeaving = event.shiftKey
+        ? event.target === panel || event.target === focusable[0]
+        : event.target === focusable[focusable.length - 1];
+
+      if (isLeaving) triggerRef.current?.focus();
+    },
+    [contentRef, triggerRef],
+  );
+
   // Re-position on scroll or resize while the panel is open.
   useEffect(() => {
     if (!isOpen) return;
@@ -314,5 +380,5 @@ export function useDropdownContent({
     };
   }, [isOpen, updatePosition, collisionDetectionRoot]);
 
-  return { position, isOpen, contentRef, contentId };
+  return { position, isOpen, contentRef, contentId, handleKeyDown };
 }

--- a/src/common/presentation/ui/dropdown/dropdown.test.tsx
+++ b/src/common/presentation/ui/dropdown/dropdown.test.tsx
@@ -8,7 +8,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-function renderDropdown() {
+function renderDropdown(panelExtras?: ReactNode) {
   return render(
     <>
       <button>outside</button>
@@ -22,10 +22,17 @@ function renderDropdown() {
         </Dropdown.Trigger>
         <Dropdown.Content>
           <button>menu content</button>
+          <button>last item</button>
+          {panelExtras}
         </Dropdown.Content>
       </Dropdown>
     </>,
   );
+}
+
+/** The portaled panel, which is the element `contentRef` points at. */
+function getPanel() {
+  return screen.getByText('menu content').parentElement;
 }
 
 describe('Dropdown', () => {
@@ -72,9 +79,33 @@ describe('Dropdown', () => {
 
     await user.click(screen.getByRole('button', { name: 'open' }));
 
-    const content = screen.getByText('menu content');
+    expect(getPanel()).toHaveAttribute('style');
+  });
+
+  it('should render the panel outside the dropdown, in document.body', async () => {
+    const user = userEvent.setup();
+    const { container } = renderDropdown();
+
+    await user.click(screen.getByRole('button', { name: 'open' }));
+
+    const panel = getPanel();
+
+    expect(container).not.toContainElement(panel);
     // eslint-disable-next-line testing-library/no-node-access
-    expect(content.parentElement).toHaveAttribute('style');
+    expect(panel?.parentElement).toBe(document.body);
+  });
+
+  it('should take the portaled panel back out of the document when closed', async () => {
+    const user = userEvent.setup();
+    renderDropdown();
+    const trigger = screen.getByRole('button', { name: 'open' });
+
+    await user.click(trigger);
+    const panel = getPanel();
+
+    await user.click(trigger);
+
+    expect(panel).not.toBeInTheDocument();
   });
 });
 
@@ -200,29 +231,105 @@ describe('dismissal', () => {
   });
 });
 
-describe('opening focus', () => {
-  it('should focus the trigger when opening', () => {
+describe('focus management', () => {
+  it('should move focus to the panel when opening', async () => {
+    const user = userEvent.setup();
     renderDropdown();
-    const trigger = screen.getByRole('button', { name: 'open' });
-    const focusSpy = jest.spyOn(trigger, 'focus');
 
-    // fireEvent, not userEvent: userEvent's own pointer choreography also
-    // focuses the clicked button, which would count alongside the explicit
-    // `triggerRef.current?.focus()` this test targets.
-    fireEvent.click(trigger);
+    await user.click(screen.getByRole('button', { name: 'open' }));
 
-    expect(focusSpy).toHaveBeenCalledTimes(1);
+    expect(getPanel()).toHaveFocus();
   });
 
-  it('should not refocus the trigger on a second toggle', () => {
+  it('should leave focus on the element clicked outside', async () => {
+    const user = userEvent.setup();
+    renderDropdown();
+
+    await user.click(screen.getByRole('button', { name: 'open' }));
+    const outside = screen.getByRole('button', { name: 'outside' });
+    await user.click(outside);
+
+    expect(screen.queryByText('menu content')).not.toBeInTheDocument();
+    expect(outside).toHaveFocus();
+  });
+
+  it('should return focus to the trigger when tabbing off the last control', async () => {
+    const user = userEvent.setup();
     renderDropdown();
     const trigger = screen.getByRole('button', { name: 'open' });
-    const focusSpy = jest.spyOn(trigger, 'focus');
 
-    fireEvent.click(trigger);
-    fireEvent.click(trigger);
+    await user.click(trigger);
+    const lastItem = screen.getByRole('button', { name: 'last item' });
+    lastItem.focus();
 
-    expect(focusSpy).toHaveBeenCalledTimes(1);
+    // fireEvent, not userEvent: what is asserted is where the handler puts
+    // focus during keydown. jsdom does not run Tab's default action, which is
+    // the half that then carries focus on past the trigger.
+    fireEvent.keyDown(lastItem, { key: 'Tab' });
+
+    expect(trigger).toHaveFocus();
+  });
+
+  it('should return focus to the trigger when shift-tabbing off the panel', async () => {
+    const user = userEvent.setup();
+    renderDropdown();
+    const trigger = screen.getByRole('button', { name: 'open' });
+
+    await user.click(trigger);
+
+    fireEvent.keyDown(getPanel()!, { key: 'Tab', shiftKey: true });
+
+    expect(trigger).toHaveFocus();
+  });
+
+  it('should return focus to the trigger when shift-tabbing off the first control', async () => {
+    const user = userEvent.setup();
+    renderDropdown();
+    const trigger = screen.getByRole('button', { name: 'open' });
+
+    await user.click(trigger);
+    const firstItem = screen.getByRole('button', { name: 'menu content' });
+    firstItem.focus();
+
+    // The container holds focus on open but its tabindex of -1 keeps it out of
+    // the sequential order, so Shift+Tab from here leaves the panel outright.
+    fireEvent.keyDown(firstItem, { key: 'Tab', shiftKey: true });
+
+    expect(trigger).toHaveFocus();
+  });
+
+  it('should find the boundary at the last control Tab can reach', async () => {
+    const user = userEvent.setup();
+    renderDropdown(
+      <>
+        <button tabIndex={-1}>programmatic only</button>
+        <button disabled>unavailable</button>
+      </>,
+    );
+    const trigger = screen.getByRole('button', { name: 'open' });
+
+    await user.click(trigger);
+    const lastItem = screen.getByRole('button', { name: 'last item' });
+    lastItem.focus();
+
+    // Both trailing buttons are focusable nodes that Tab never lands on, so
+    // neither is the end of the panel's tab order.
+    fireEvent.keyDown(lastItem, { key: 'Tab' });
+
+    expect(trigger).toHaveFocus();
+  });
+
+  it('should not move focus when tabbing between panel controls', async () => {
+    const user = userEvent.setup();
+    renderDropdown();
+
+    await user.click(screen.getByRole('button', { name: 'open' }));
+    const firstItem = screen.getByRole('button', { name: 'menu content' });
+    firstItem.focus();
+
+    fireEvent.keyDown(firstItem, { key: 'Tab' });
+
+    expect(firstItem).toHaveFocus();
   });
 });
 

--- a/src/common/presentation/ui/dropdown/dropdown.test.tsx
+++ b/src/common/presentation/ui/dropdown/dropdown.test.tsx
@@ -175,7 +175,7 @@ describe('dismissal', () => {
     expect(screen.getByText('menu content')).toBeInTheDocument();
   });
 
-  it('should leave the panel open when Escape is pressed outside the dropdown', async () => {
+  it('should close when Escape is pressed outside the dropdown', async () => {
     const user = userEvent.setup();
     renderDropdown();
 
@@ -183,6 +183,18 @@ describe('dismissal', () => {
     const outside = screen.getByRole('button', { name: 'outside' });
 
     fireEvent.keyDown(outside, { key: 'Escape' });
+
+    expect(screen.queryByText('menu content')).not.toBeInTheDocument();
+  });
+
+  it('should reopen after Escape closed it', async () => {
+    const user = userEvent.setup();
+    renderDropdown();
+    const trigger = screen.getByRole('button', { name: 'open' });
+
+    await user.click(trigger);
+    fireEvent.keyDown(trigger, { key: 'Escape' });
+    await user.click(trigger);
 
     expect(screen.getByText('menu content')).toBeInTheDocument();
   });
@@ -237,8 +249,39 @@ describe('useDropdown', () => {
       toggle: expect.any(Function),
       close: expect.any(Function),
       triggerRef: expect.objectContaining({ current: null }),
+      contentRef: expect.objectContaining({ current: null }),
       collisionDetectionRoot: null,
       contentId: expect.any(String),
     });
+  });
+
+  it('should hold the rendered panel in contentRef', async () => {
+    const user = userEvent.setup();
+
+    function wrapper({ children }: { children: ReactNode }) {
+      return (
+        <Dropdown>
+          {children}
+          <Dropdown.Trigger>
+            {({ ref, onClick }) => (
+              <button ref={ref} onClick={onClick}>
+                open
+              </button>
+            )}
+          </Dropdown.Trigger>
+          <Dropdown.Content>
+            <button>menu content</button>
+          </Dropdown.Content>
+        </Dropdown>
+      );
+    }
+
+    const { result } = renderHook(() => useDropdown(), { wrapper });
+    await user.click(screen.getByRole('button', { name: 'open' }));
+
+    expect(result.current.contentRef.current).toBe(
+      // eslint-disable-next-line testing-library/no-node-access
+      screen.getByText('menu content').parentElement,
+    );
   });
 });

--- a/src/common/presentation/ui/dropdown/dropdown.tsx
+++ b/src/common/presentation/ui/dropdown/dropdown.tsx
@@ -49,14 +49,20 @@ export function Dropdown({
   const rootRef = useRef<HTMLDivElement>(null);
   const contentId = useId();
 
-  const close = useCallback(() => setIsOpen(false), []);
+  const close = useCallback(() => {
+    // Read now, before the panel unmounts: afterwards activeElement is <body>,
+    // which answers false both for the case that has to restore focus and for
+    // the case that must not. Restoring unconditionally would take focus back
+    // from an element the user clicked outside, and from a modal that a panel
+    // button opened just before closing the dropdown.
+    if (contentRef.current?.contains(document.activeElement)) {
+      triggerRef.current?.focus();
+    }
 
-  const toggle = useCallback(() => {
-    // A pointer open leaves focus on <body> in Safari, which does not focus a
-    // button on click. Without this the panel is unreachable by Tab.
-    if (!isOpen) triggerRef.current?.focus();
-    setIsOpen((prev) => !prev);
-  }, [isOpen]);
+    setIsOpen(false);
+  }, []);
+
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -73,10 +79,10 @@ export function Dropdown({
       if (next && isOutside(next)) close();
     };
 
+    // close() restores focus to the trigger on its own when focus is in the
+    // panel, which is where Escape finds it.
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return;
-      close();
-      triggerRef.current?.focus();
+      if (event.key === 'Escape') close();
     };
 
     const handleClickOutside = (event: MouseEvent) => {

--- a/src/common/presentation/ui/dropdown/dropdown.tsx
+++ b/src/common/presentation/ui/dropdown/dropdown.tsx
@@ -18,6 +18,7 @@ type DropdownContextValue = {
   toggle: () => void;
   close: () => void;
   triggerRef: RefObject<HTMLButtonElement | null>;
+  contentRef: RefObject<HTMLDivElement | null>;
   collisionDetectionRoot: HTMLElement | null;
   contentId: string;
 } | null;
@@ -44,6 +45,7 @@ export function Dropdown({
 }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const contentId = useId();
 
@@ -51,21 +53,24 @@ export function Dropdown({
 
   const toggle = useCallback(() => {
     // A pointer open leaves focus on <body> in Safari, which does not focus a
-    // button on click. Without this the panel is unreachable by Tab and the
-    // root-scoped Escape handler never fires.
+    // button on click. Without this the panel is unreachable by Tab.
     if (!isOpen) triggerRef.current?.focus();
     setIsOpen((prev) => !prev);
   }, [isOpen]);
 
   useEffect(() => {
-    const root = rootRef.current;
-    if (!isOpen || !root) return;
+    if (!isOpen) return;
+
+    // Both refs are read at event time rather than captured here, so the
+    // effect does not need to re-run when the panel mounts.
+    const isOutside = (node: Node | null) =>
+      !rootRef.current?.contains(node) && !contentRef.current?.contains(node);
 
     const handleFocusOut = (event: FocusEvent) => {
       const next = event.relatedTarget as Node | null;
       // null when focus leaves the document entirely (window switch,
       // devtools), which must not close the panel.
-      if (next && !root.contains(next)) close();
+      if (next && isOutside(next)) close();
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -75,19 +80,21 @@ export function Dropdown({
     };
 
     const handleClickOutside = (event: MouseEvent) => {
-      if (!root.contains(event.target as Node)) close();
+      if (isOutside(event.target as Node)) close();
     };
 
-    root.addEventListener('focusout', handleFocusOut);
-    root.addEventListener('keydown', handleKeyDown);
+    // All three bind to document rather than to the root, so they keep firing
+    // for a panel that is not a descendant of the root.
+    document.addEventListener('focusout', handleFocusOut);
+    document.addEventListener('keydown', handleKeyDown);
     document.addEventListener('click', handleClickOutside);
 
     return () => {
-      root.removeEventListener('focusout', handleFocusOut);
-      root.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('focusout', handleFocusOut);
+      document.removeEventListener('keydown', handleKeyDown);
       document.removeEventListener('click', handleClickOutside);
     };
-  }, [isOpen, close, triggerRef]);
+  }, [isOpen, close]);
 
   return (
     <DropdownContext
@@ -96,6 +103,7 @@ export function Dropdown({
         toggle,
         close,
         triggerRef,
+        contentRef,
         collisionDetectionRoot,
         contentId,
       }}

--- a/src/common/presentation/ui/stacking-order.test.tsx
+++ b/src/common/presentation/ui/stacking-order.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+
+import { DropdownContent } from '@/ui/dropdown/compounds/content/content';
+import { useDropdownContent } from '@/ui/dropdown/compounds/content/use-content';
+import { NavBar } from '@/ui/nav-bar/nav-bar';
+import { Toaster } from '@/ui/toaster/toaster';
+
+jest.mock('@/ui/dropdown/compounds/content/use-content', () => ({
+  useDropdownContent: jest.fn(),
+}));
+
+// These three elements are fixed, siblings in the root stacking context, and
+// each owns its z-index in its own file. Nothing in any one file states the
+// order they have to keep, so this reads the values back and asserts it.
+function stackingOrder(element: HTMLElement) {
+  const utility = element.className
+    .split(/\s+/)
+    .find((className) => /^z-\d+$/.test(className));
+
+  if (!utility) throw new Error(`no z utility found on <${element.tagName}>`);
+
+  return Number(utility.replace('z-', ''));
+}
+
+async function renderFixedElements() {
+  (useDropdownContent as jest.Mock).mockReturnValue({
+    isOpen: true,
+    position: { top: 0, left: 0 },
+    contentRef: createRef(),
+  });
+
+  render(
+    <>
+      <NavBar>nav</NavBar>
+      <DropdownContent>menu items</DropdownContent>
+      <Toaster />
+    </>,
+  );
+
+  return {
+    navBar: screen.getByRole('banner'),
+    panel: screen.getByText('menu items'),
+    toaster: await screen.findByRole('region', { name: /notifications/i }),
+  };
+}
+
+describe('stacking order', () => {
+  it('should paint a dropdown panel above the nav bar', async () => {
+    const { navBar, panel } = await renderFixedElements();
+
+    expect(stackingOrder(panel)).toBeGreaterThan(stackingOrder(navBar));
+  });
+
+  it('should paint a toast above an open dropdown panel', async () => {
+    const { panel, toaster } = await renderFixedElements();
+
+    expect(stackingOrder(toaster)).toBeGreaterThan(stackingOrder(panel));
+  });
+});

--- a/src/common/presentation/ui/toaster/toaster.tsx
+++ b/src/common/presentation/ui/toaster/toaster.tsx
@@ -22,7 +22,7 @@ export function Toaster({ maxToasts = 3, toastLifeTime }: ToasterProps) {
   return (
     <section
       aria-label="notifications"
-      className="fixed bottom-0 z-50 w-full p-2 md:right-0 md:m-5 md:max-w-sm"
+      className="fixed bottom-0 z-70 w-full p-2 md:right-0 md:m-5 md:max-w-sm"
     >
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions --
           the list is not interactive. These pause the dismiss timer while a toast's

--- a/test/e2e/keyboard_navigation.test.ts
+++ b/test/e2e/keyboard_navigation.test.ts
@@ -83,6 +83,62 @@ async function collectTabStops(page: Page): Promise<FocusedElementState[]> {
   return stops;
 }
 
+/**
+ * Stamps whatever holds focus so a later focus can be recognised as the same
+ * element. Accessible names repeat across a table's headers, so they cannot
+ * identify one tab stop on their own.
+ */
+function markFocused(page: Page, mark: string) {
+  return page.evaluate(
+    (value) => document.activeElement?.setAttribute('data-focus-mark', value),
+    mark,
+  );
+}
+
+function readFocusMark(page: Page) {
+  return page.evaluate(
+    () => document.activeElement?.getAttribute('data-focus-mark') ?? null,
+  );
+}
+
+/**
+ * True while focus is inside the panel the trigger controls. Goes through
+ * getElementById rather than a locator: the id comes from React's useId, whose
+ * delimiters are not valid in a CSS selector.
+ */
+function isFocusInPanel(page: Page, panelId: string) {
+  return page.evaluate((id) => {
+    const panel = document.getElementById(id);
+
+    return panel !== null && panel.contains(document.activeElement);
+  }, panelId);
+}
+
+/** Opens the trigger's panel and returns the panel's id. */
+async function openPanel(trigger: Locator): Promise<string> {
+  await trigger.focus();
+  await trigger.page().keyboard.press('Enter');
+
+  await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+  const panelId = await trigger.getAttribute('aria-controls');
+
+  if (!panelId) throw new Error('An open trigger exposes no aria-controls.');
+
+  return panelId;
+}
+
+/** Tabs forwards until focus is no longer anywhere inside the panel. */
+async function pressTabUntilOutOfPanel(page: Page, panelId: string) {
+  for (let stop = 0; stop < MAX_TAB_STOPS; stop++) {
+    if (!(await isFocusInPanel(page, panelId))) return;
+
+    await page.keyboard.press('Tab');
+  }
+
+  throw new Error(`Focus never left the panel within ${MAX_TAB_STOPS} stops.`);
+}
+
 /** True while focus sits on an element that is still attached to the document. */
 function isFocusAttached(page: Page) {
   return page.evaluate(
@@ -121,7 +177,8 @@ test.describe('keyboard_navigation - column dropdown - @desktop', () => {
 
     await expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
-    // The panel renders in place, so the very next tab stop is inside it.
+    // Opening puts focus on the panel container, so the next tab stop is the
+    // panel's own first control.
     await page.keyboard.press('Tab');
     await expect(page.getByRole('checkbox', { name: 'All' })).toBeFocused();
 
@@ -140,6 +197,71 @@ test.describe('keyboard_navigation - column dropdown - @desktop', () => {
 
     await expect(trigger).toHaveAttribute('aria-expanded', 'false');
     await expect(trigger).toBeFocused();
+  });
+});
+
+test.describe('keyboard_navigation - panel tab boundary - @desktop', () => {
+  // The panel is portaled to the end of the body, so DOM order would otherwise
+  // send a Tab off its last control past the whole page and a Shift+Tab back
+  // into it. Both journeys assert the page keeps tabbing from the trigger's
+  // own place instead. jsdom cannot observe either: they rest on the browser
+  // resolving Tab's default action against the focus the handler just moved.
+  test('tabbing off the panel resumes after the trigger and closes it - @desktop', async ({
+    keyboardPage,
+  }) => {
+    const { page, carId } = keyboardPage;
+
+    await page.goto(carRoute(carId));
+
+    await expect(
+      page.getByRole('table', { name: 'car service logs' }),
+    ).toBeVisible();
+
+    const trigger = page.getByRole('button', { name: 'Category', exact: true });
+
+    // Where Tab lands from the closed trigger is the reference the journey has
+    // to match, and it is read before the panel exists so nothing about the
+    // panel's own position can decide it.
+    await trigger.focus();
+    await page.keyboard.press('Tab');
+    await markFocused(page, 'after-trigger');
+
+    const panelId = await openPanel(trigger);
+
+    await pressTabUntilOutOfPanel(page, panelId);
+
+    expect(await isFocusAttached(page)).toBe(true);
+    expect(await readFocusMark(page)).toBe('after-trigger');
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('shift-tabbing off the panel resumes before the trigger and closes it - @desktop', async ({
+    keyboardPage,
+  }) => {
+    const { page, carId } = keyboardPage;
+
+    await page.goto(carRoute(carId));
+
+    await expect(
+      page.getByRole('table', { name: 'car service logs' }),
+    ).toBeVisible();
+
+    const trigger = page.getByRole('button', { name: 'Category', exact: true });
+
+    await trigger.focus();
+    await page.keyboard.press('Shift+Tab');
+    await markFocused(page, 'before-trigger');
+
+    await openPanel(trigger);
+
+    // Opening leaves focus on the panel container, which is already the
+    // backwards boundary: its tabindex of -1 keeps it out of the sequential
+    // order, so one Shift+Tab leaves the panel outright.
+    await page.keyboard.press('Shift+Tab');
+
+    expect(await isFocusAttached(page)).toBe(true);
+    expect(await readFocusMark(page)).toBe('before-trigger');
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 });
 


### PR DESCRIPTION
## Summary

- `Dropdown.Content` renders into `document.body` through a portal, so nothing above the trigger can move or clip the panel.
- Focus is managed explicitly now that DOM order no longer connects the trigger to the panel: opening focuses the panel container, closing returns focus to the trigger only when focus is still inside the panel, and Tab off either end sends focus to the trigger.
- All three dismissal listeners bind to the document and ask containment against both the root and the panel, so Escape closes an open panel from anywhere on the page.
- Gives the nav bar, panel, and toaster distinct z-index values, with a test that reads them back off the rendered elements and asserts the ordering.
- Drops the Safari focus-on-toggle workaround, whose two jobs are both handled elsewhere now.

## Why

`fixed` resolves against the viewport only while no ancestor establishes a containing block, and a transform, filter, backdrop-filter, contain, or container-type is enough to establish one. Rendered inline, the panel would land offset and clipped the moment a style was set above it, with nothing in the failure pointing at the cause. Separately, the panel at `z-20` painted behind the nav bar whenever collision detection flipped it upward from a first table row.

## Key points

- The Tab handler moves focus but leaves the default action to run. The browser resolves the next tab stop against whatever holds focus when the handler returns, which is what makes the page continue from the trigger's place in document order rather than from the end of the body.
- Backwards, the panel container counts as a boundary alongside its first control: it holds focus on open, and its `tabindex` of -1 keeps it out of the sequential order.
- `close()` reads `document.activeElement` before unmounting the panel. Restoring focus unconditionally would take it back from an element clicked outside, or from a modal a panel button just opened.
- The focusable lookup filters on `tabIndex >= 0` and `:not(:disabled)` rather than a tag-name list, so an explicit `tabindex="-1"` and `fieldset`-inherited disabling are both respected.
- The two Tab-boundary journeys are e2e only: jsdom does not run Tab's default action, which is the half that carries focus past the trigger.