### PR TITLE
feat(dashboard): add a nav mode preference

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,12 +1,29 @@
+import { cookies } from 'next/headers';
 import type { ReactNode } from 'react';
 
 import { DashboardNavBar } from '@/dashboard/ui/nav-bar/nav-bar';
+import {
+  NAV_MODE_COOKIE_NAME,
+  parseNavMode,
+} from '@/dashboard/ui/nav-mode/nav-mode';
 
-export default function DashboardLayout({ children }: { children: ReactNode }) {
+export default async function DashboardLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const cookieStore = await cookies();
+  const navMode = parseNavMode(cookieStore.get(NAV_MODE_COOKIE_NAME)?.value);
+
   return (
-    <>
-      <DashboardNavBar />
+    // All three modes are CSS keyed off this attribute, so it has to sit above
+    // both the nav and the page's main region. Resolving it on the server is
+    // what keeps the first frame right: getting it wrong for a frame would
+    // shift the whole dashboard sideways by the difference between the nav's
+    // two widths.
+    <div data-nav-mode={navMode}>
+      <DashboardNavBar navMode={navMode} />
       {children}
-    </>
+    </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,17 @@
 @custom-variant dark (&:is(.dark *));
 @custom-variant item-active (&:is(.item-active *));
 
+/*
+  The dashboard shell carries `data-nav-mode`, rendered from a cookie on the
+  server so the first frame is already in the mode the user chose.
+
+  There is no `nav-collapsed` variant. Collapsed is the resting state every
+  rule already describes, so a rule scoped to it could only restate what the
+  unscoped rule says.
+*/
+@custom-variant nav-auto (&:is([data-nav-mode='auto'] *));
+@custom-variant nav-expanded (&:is([data-nav-mode='expanded'] *));
+
 @theme {
   --color-*: initial;
   --color-dark-50: var(--color-dark-50);

--- a/src/common/presentation/ui/decorative/icons/sidebar.tsx
+++ b/src/common/presentation/ui/decorative/icons/sidebar.tsx
@@ -1,0 +1,15 @@
+import type { SvgA11yProps } from '../svg-a11y/svg-a11y';
+import { SvgA11y } from '../svg-a11y/svg-a11y';
+
+export function SidebarIcon({ ...props }: SvgA11yProps) {
+  return (
+    <SvgA11y
+      {...props}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      viewBox="0 0 50 50"
+    >
+      <path d="M14 43.462h29.462A5.54 5.54 0 0 0 49 37.923V12.077a5.54 5.54 0 0 0-5.538-5.538H14m0 36.923H6.538A5.54 5.54 0 0 1 1 37.923V12.077a5.54 5.54 0 0 1 5.538-5.538H14m0 36.923V6.539" />
+    </SvgA11y>
+  );
+}

--- a/src/module/dashboard/ui/main/main.tsx
+++ b/src/module/dashboard/ui/main/main.tsx
@@ -14,7 +14,11 @@ export function DashboardMain({ children, className }: DashboardMainProps) {
         // scrollbar, so it exceeds the content box by the gutter width.
         // Safe centering so that content wider than the viewport overflows the
         // end edge only, where it stays reachable by scrolling.
-        'flex min-h-screen max-w-full items-center-safe justify-center-safe pt-16 md:pl-16',
+        // The padding tracks the nav's resting width, so an expanded nav takes
+        // the width from here rather than covering what is under it. It is not
+        // transitioned: a mode change is instant, and animating this width
+        // would make every page re-resolve its layout on each frame.
+        'md:nav-expanded:pl-56 flex min-h-screen max-w-full items-center-safe justify-center-safe pt-16 md:pl-16',
         className,
       )}
     >

--- a/src/module/dashboard/ui/main/main.tsx
+++ b/src/module/dashboard/ui/main/main.tsx
@@ -18,7 +18,7 @@ export function DashboardMain({ children, className }: DashboardMainProps) {
         // the width from here rather than covering what is under it. It is not
         // transitioned: a mode change is instant, and animating this width
         // would make every page re-resolve its layout on each frame.
-        'md:nav-expanded:pl-56 flex min-h-screen max-w-full items-center-safe justify-center-safe pt-16 md:pl-16',
+        'md:nav-expanded:pl-56 flex min-h-screen max-w-full items-center-safe justify-center-safe pt-16 transition-none md:pl-16',
         className,
       )}
     >

--- a/src/module/dashboard/ui/nav-bar/nav-bar.test.tsx
+++ b/src/module/dashboard/ui/nav-bar/nav-bar.test.tsx
@@ -13,7 +13,7 @@ jest.mock('next/navigation', () => ({
 function TestDashboardNavBar() {
   return (
     <TanStackQueryProvider>
-      <DashboardNavBar />
+      <DashboardNavBar navMode="auto" />
     </TanStackQueryProvider>
   );
 }

--- a/src/module/dashboard/ui/nav-bar/nav-bar.tsx
+++ b/src/module/dashboard/ui/nav-bar/nav-bar.tsx
@@ -1,31 +1,23 @@
 'use client';
 
-import { useId, useState } from 'react';
-
 import { BrandLabel } from '@/ui/brand-label/brand-label';
 import { Spinner } from '@/ui/decorative/spinner/spinner';
 import { HamburgerButton } from '@/ui/hamburger-button/hamburger-button';
 import { NavBar } from '@/ui/nav-bar/nav-bar';
-import { useSessionUser } from '@/user/presentation/hook/use-session-user';
 import { UserBadge } from '@/user/presentation/ui/badge/badge';
 
 import { NavBarNav } from './nav/nav';
+import { useDashboardNavBar } from './use-nav-bar';
 
 export function DashboardNavBar() {
-  const { data, isPending } = useSessionUser();
-
-  const navId = useId();
-  const [isActive, setIsActive] = useState(false);
-
-  const handleHamburgerButtonClick = () => {
-    setIsActive((currentState) => !currentState);
-  };
-
-  const handleNavClick = () => {
-    if (isActive) {
-      setIsActive(false);
-    }
-  };
+  const {
+    user,
+    isPending,
+    navId,
+    isActive,
+    handleHamburgerButtonClick,
+    handleNavClick,
+  } = useDashboardNavBar();
 
   return (
     <NavBar>
@@ -33,7 +25,7 @@ export function DashboardNavBar() {
       {isPending && (
         <Spinner className="fill-accent-400 stroke-accent-400 z-10 h-full" />
       )}
-      {data && <UserBadge className="z-10" user={data} />}
+      {user && <UserBadge className="z-10" user={user} />}
       <HamburgerButton
         aria-controls={navId}
         aria-expanded={isActive}

--- a/src/module/dashboard/ui/nav-bar/nav-bar.tsx
+++ b/src/module/dashboard/ui/nav-bar/nav-bar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { NavMode } from '@/dashboard/ui/nav-mode/nav-mode';
 import { BrandLabel } from '@/ui/brand-label/brand-label';
 import { Spinner } from '@/ui/decorative/spinner/spinner';
 import { HamburgerButton } from '@/ui/hamburger-button/hamburger-button';
@@ -9,7 +10,11 @@ import { UserBadge } from '@/user/presentation/ui/badge/badge';
 import { NavBarNav } from './nav/nav';
 import { useDashboardNavBar } from './use-nav-bar';
 
-export function DashboardNavBar() {
+type DashboardNavBarProps = {
+  navMode: NavMode;
+};
+
+export function DashboardNavBar({ navMode }: DashboardNavBarProps) {
   const {
     user,
     isPending,
@@ -36,6 +41,7 @@ export function DashboardNavBar() {
       <NavBarNav
         id={navId}
         isActive={isActive}
+        navMode={navMode}
         onClose={handleNavClick}
         onNavigate={handleNavClick}
       />

--- a/src/module/dashboard/ui/nav-bar/nav/item/item.tsx
+++ b/src/module/dashboard/ui/nav-bar/nav/item/item.tsx
@@ -40,7 +40,7 @@ export function NavItem({
         onClick={onNavigate}
       >
         <div className="h-full md:shrink-0">{children}</div>
-        <span className="text-alpha-grey-900 dark:text-alpha-grey-800 item-active:text-dark-500 item-active:dark:text-light-500 whitespace-nowrap transition-all md:translate-x-0 md:opacity-0 md:@[64px]:translate-x-1 md:@[64px]:opacity-100">
+        <span className="text-alpha-grey-900 dark:text-alpha-grey-800 item-active:text-dark-500 item-active:dark:text-light-500 whitespace-nowrap transition-all motion-reduce:transition-none md:translate-x-0 md:opacity-0 md:@[64px]:translate-x-1 md:@[64px]:opacity-100">
           {text}
         </span>
       </LinkButton>

--- a/src/module/dashboard/ui/nav-bar/nav/mode-dropdown/content/content.tsx
+++ b/src/module/dashboard/ui/nav-bar/nav/mode-dropdown/content/content.tsx
@@ -1,0 +1,56 @@
+import type { NavMode } from '@/dashboard/ui/nav-mode/nav-mode';
+import { NAV_MODES } from '@/dashboard/ui/nav-mode/nav-mode';
+import { CheckIcon } from '@/icons/check';
+import { Dropdown } from '@/ui/dropdown/dropdown';
+import { IconButton } from '@/ui/icon-button/icon-button';
+
+import { NAV_MODE_LABELS } from '../nav-mode-labels';
+import { useNavModeDropdownContent } from './use-content';
+
+type NavModeDropdownContentProps = {
+  mode: NavMode;
+  onSelect: (mode: NavMode) => void;
+};
+
+export function NavModeDropdownContent({
+  mode,
+  onSelect,
+}: NavModeDropdownContentProps) {
+  const { handleSelect } = useNavModeDropdownContent({ onSelect });
+
+  return (
+    <Dropdown.Content align="start" side="top">
+      {/* One button per mode rather than a radio group. A radio group is a
+          single tab stop by design: Tab lands on the mode already in use and
+          the next Tab leaves the panel, which leaves the other two modes
+          reachable only by arrow keys, and an arrow key there both moves and
+          picks. A button per mode is one tab stop per mode, and picking stays
+          a deliberate press. */}
+      <fieldset className="p-1">
+        <legend>
+          <span className="sr-only">Navigation menu mode</span>
+        </legend>
+
+        <div className="flex flex-col gap-1">
+          {NAV_MODES.map((option) => (
+            <IconButton
+              key={option}
+              aria-pressed={option === mode}
+              className="w-full justify-between"
+              size="sm"
+              text={NAV_MODE_LABELS[option]}
+              variant="transparent"
+              onClick={() => handleSelect(option)}
+            >
+              {/* Rendered on every option so the labels keep their place as
+                  the mark moves between them. */}
+              <CheckIcon
+                className={`h-5 w-5 stroke-4 p-0.5 ${option === mode ? 'stroke-accent-500' : 'stroke-transparent'}`}
+              />
+            </IconButton>
+          ))}
+        </div>
+      </fieldset>
+    </Dropdown.Content>
+  );
+}

--- a/src/module/dashboard/ui/nav-bar/nav/mode-dropdown/content/use-content.ts
+++ b/src/module/dashboard/ui/nav-bar/nav/mode-dropdown/content/use-content.ts
@@ -1,0 +1,25 @@
+import type { NavMode } from '@/dashboard/ui/nav-mode/nav-mode';
+import { applyNavMode } from '@/dashboard/ui/nav-mode/nav-mode';
+import { useDropdown } from '@/ui/dropdown/dropdown';
+
+type UseNavModeDropdownContentParams = {
+  onSelect: (mode: NavMode) => void;
+};
+
+export function useNavModeDropdownContent({
+  onSelect,
+}: UseNavModeDropdownContentParams) {
+  const { close } = useDropdown();
+
+  const handleSelect = (mode: NavMode) => {
+    onSelect(mode);
+    applyNavMode(mode);
+
+    // Picking a mode is the whole errand, and the result is visible behind the
+    // panel. Closing also hands focus back to the trigger, whose name is what
+    // reports which mode is now active.
+    close();
+  };
+
+  return { handleSelect };
+}

--- a/src/module/dashboard/ui/nav-bar/nav/mode-dropdown/mode-dropdown.test.tsx
+++ b/src/module/dashboard/ui/nav-bar/nav/mode-dropdown/mode-dropdown.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { applyNavMode } from '@/dashboard/ui/nav-mode/nav-mode';
+
+import { NavModeDropdown } from './mode-dropdown';
+
+// Only the write is mocked. The module also carries the vocabulary the panel
+// renders from, and a bare factory would empty it.
+jest.mock('@/dashboard/ui/nav-mode/nav-mode', () => ({
+  ...jest.requireActual('@/dashboard/ui/nav-mode/nav-mode'),
+  applyNavMode: jest.fn(),
+}));
+
+const mockApplyNavMode = applyNavMode as jest.Mock;
+
+function trigger() {
+  return screen.getByRole('button', { name: /^navigation menu mode:/i });
+}
+
+function option(name: string) {
+  return screen.getByRole('button', { name });
+}
+
+describe('NavModeDropdown', () => {
+  it('should report the current mode in the trigger name', () => {
+    render(<NavModeDropdown navMode="collapsed" />);
+
+    expect(trigger()).toHaveAccessibleName('Navigation menu mode: Collapsed');
+  });
+
+  it('should offer all three modes', async () => {
+    const user = userEvent.setup();
+    render(<NavModeDropdown navMode="auto" />);
+
+    await user.click(trigger());
+
+    expect(option('Auto')).toBeInTheDocument();
+    expect(option('Collapsed')).toBeInTheDocument();
+    expect(option('Expanded')).toBeInTheDocument();
+  });
+
+  it('should mark the current mode as the one in use', async () => {
+    const user = userEvent.setup();
+    render(<NavModeDropdown navMode="expanded" />);
+
+    await user.click(trigger());
+
+    expect(option('Expanded')).toHaveAttribute('aria-pressed', 'true');
+    expect(option('Auto')).toHaveAttribute('aria-pressed', 'false');
+    expect(option('Collapsed')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('should give every mode its own tab stop', async () => {
+    const user = userEvent.setup();
+    render(<NavModeDropdown navMode="auto" />);
+
+    await user.click(trigger());
+
+    // The mode in use is not the panel's only tab stop, so the two modes the
+    // user does not have are reachable without arrow keys.
+    await user.tab();
+    expect(option('Auto')).toHaveFocus();
+
+    await user.tab();
+    expect(option('Collapsed')).toHaveFocus();
+
+    await user.tab();
+    expect(option('Expanded')).toHaveFocus();
+  });
+
+  it('should persist and apply the selected mode', async () => {
+    const user = userEvent.setup();
+    render(<NavModeDropdown navMode="auto" />);
+
+    await user.click(trigger());
+    await user.click(option('Expanded'));
+
+    expect(mockApplyNavMode).toHaveBeenCalledWith('expanded');
+  });
+
+  it('should close the panel once a mode is picked', async () => {
+    const user = userEvent.setup();
+    render(<NavModeDropdown navMode="auto" />);
+
+    await user.click(trigger());
+    await user.click(option('Expanded'));
+
+    expect(
+      screen.queryByRole('button', { name: 'Expanded' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should return focus to the trigger once a mode is picked', async () => {
+    const user = userEvent.setup();
+    render(<NavModeDropdown navMode="auto" />);
+
+    await user.click(trigger());
+    await user.click(option('Expanded'));
+
+    expect(trigger()).toHaveFocus();
+  });
+
+  it('should move the mark to the selected mode', async () => {
+    const user = userEvent.setup();
+    render(<NavModeDropdown navMode="auto" />);
+
+    await user.click(trigger());
+    await user.click(option('Collapsed'));
+    await user.click(trigger());
+
+    expect(option('Collapsed')).toHaveAttribute('aria-pressed', 'true');
+    expect(option('Auto')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('should report the selected mode in the trigger name', async () => {
+    const user = userEvent.setup();
+    render(<NavModeDropdown navMode="auto" />);
+
+    await user.click(trigger());
+    await user.click(option('Collapsed'));
+
+    expect(trigger()).toHaveAccessibleName('Navigation menu mode: Collapsed');
+  });
+});

--- a/src/module/dashboard/ui/nav-bar/nav/mode-dropdown/mode-dropdown.tsx
+++ b/src/module/dashboard/ui/nav-bar/nav/mode-dropdown/mode-dropdown.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+
+import type { NavMode } from '@/dashboard/ui/nav-mode/nav-mode';
+import { SidebarIcon } from '@/icons/sidebar';
+import { Dropdown } from '@/ui/dropdown/dropdown';
+import { IconButton } from '@/ui/icon-button/icon-button';
+
+import { NavModeDropdownContent } from './content/content';
+import { NAV_MODE_LABELS } from './nav-mode-labels';
+
+type NavModeDropdownProps = {
+  navMode: NavMode;
+  className?: string;
+};
+
+export function NavModeDropdown({ navMode, className }: NavModeDropdownProps) {
+  // Seeded from the cookie the server read, and owned here afterwards. The
+  // mode itself lives on the shell's data attribute rather than in React, so
+  // this state exists only to mark the checked option and to name the trigger.
+  const [mode, setMode] = useState(navMode);
+
+  return (
+    <Dropdown className={className}>
+      <Dropdown.Trigger>
+        {(triggerProps) => (
+          <IconButton
+            {...triggerProps}
+            className="h-full w-full"
+            size="icon"
+            // `auto` and `collapsed` are identical at rest, so the name has to
+            // report which one is active; nothing on screen distinguishes them.
+            title={`Navigation menu mode: ${NAV_MODE_LABELS[mode]}`}
+            variant="transparent"
+          >
+            <SidebarIcon className="stroke-dark-500 dark:stroke-light-500 h-full w-full stroke-2" />
+          </IconButton>
+        )}
+      </Dropdown.Trigger>
+
+      <NavModeDropdownContent mode={mode} onSelect={setMode} />
+    </Dropdown>
+  );
+}

--- a/src/module/dashboard/ui/nav-bar/nav/mode-dropdown/nav-mode-labels.ts
+++ b/src/module/dashboard/ui/nav-bar/nav/mode-dropdown/nav-mode-labels.ts
@@ -1,0 +1,8 @@
+import type { NavMode } from '@/dashboard/ui/nav-mode/nav-mode';
+
+/** Shared by the trigger, which names the current mode, and by the options. */
+export const NAV_MODE_LABELS: Record<NavMode, string> = {
+  auto: 'Auto',
+  collapsed: 'Collapsed',
+  expanded: 'Expanded',
+};

--- a/src/module/dashboard/ui/nav-bar/nav/nav.test.tsx
+++ b/src/module/dashboard/ui/nav-bar/nav/nav.test.tsx
@@ -9,7 +9,7 @@ jest.mock('next/navigation', () => ({
 
 describe('NavBarNav', () => {
   it('should render dashboard navigation menu', () => {
-    render(<NavBarNav />);
+    render(<NavBarNav navMode="auto" />);
 
     const dashboardMenu = screen.getByRole('navigation', {
       name: /dashboard navigation menu/i,
@@ -19,7 +19,7 @@ describe('NavBarNav', () => {
   });
 
   it('should render a link to dashboard root tab', () => {
-    render(<NavBarNav />);
+    render(<NavBarNav navMode="auto" />);
 
     const dashboardHomeLink = screen.getByRole('link', { name: /overview/i });
 
@@ -27,7 +27,7 @@ describe('NavBarNav', () => {
   });
 
   it('should render a link to dashboard cars tab', () => {
-    render(<NavBarNav />);
+    render(<NavBarNav navMode="auto" />);
 
     const dashboardCarsLink = screen.getByRole('link', { name: /cars/i });
 
@@ -35,7 +35,7 @@ describe('NavBarNav', () => {
   });
 
   it('should render a link to dashboard account settings tab', () => {
-    render(<NavBarNav />);
+    render(<NavBarNav navMode="auto" />);
 
     const dashboardAccountLink = screen.getByRole('link', { name: /account/i });
 
@@ -43,15 +43,25 @@ describe('NavBarNav', () => {
   });
 
   it('should render a link to sign out', () => {
-    render(<NavBarNav />);
+    render(<NavBarNav navMode="auto" />);
 
     const signOutLink = screen.getByRole('link', { name: /sign out/i });
 
     expect(signOutLink).toBeInTheDocument();
   });
 
+  it('should render a nav mode control reporting the current mode', () => {
+    render(<NavBarNav navMode="expanded" />);
+
+    const navModeControl = screen.getByRole('button', {
+      name: 'Navigation menu mode: Expanded',
+    });
+
+    expect(navModeControl).toBeInTheDocument();
+  });
+
   it('should render a color theme switch button', () => {
-    render(<NavBarNav />);
+    render(<NavBarNav navMode="auto" />);
 
     const themeSwitchButton = screen.getByRole('button', {
       name: /switch to (dark|light) theme/i,
@@ -61,7 +71,7 @@ describe('NavBarNav', () => {
   });
 
   it('should stay visible when active', () => {
-    render(<NavBarNav isActive />);
+    render(<NavBarNav isActive navMode="auto" />);
 
     const dashboardMenu = screen.getByRole('navigation', {
       name: /dashboard navigation menu/i,
@@ -72,7 +82,7 @@ describe('NavBarNav', () => {
   });
 
   it('should leave the tab order when inactive', () => {
-    render(<NavBarNav isActive={false} />);
+    render(<NavBarNav isActive={false} navMode="auto" />);
 
     const dashboardMenu = screen.getByRole('navigation', {
       name: /dashboard navigation menu/i,

--- a/src/module/dashboard/ui/nav-bar/nav/nav.test.tsx
+++ b/src/module/dashboard/ui/nav-bar/nav/nav.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { NavBarNav } from './nav';
 
@@ -90,5 +91,68 @@ describe('NavBarNav', () => {
 
     expect(dashboardMenu).toHaveClass('invisible');
     expect(dashboardMenu).not.toHaveClass('visible');
+  });
+
+  it('should hold its reveal while it contains a visible focus', () => {
+    render(<NavBarNav navMode="auto" />);
+
+    const dashboardMenu = screen.getByRole('navigation', {
+      name: /dashboard navigation menu/i,
+    });
+
+    // `:focus-visible`, not `:focus-within`: a click leaves the control it
+    // landed on focused, and holding the reveal for that would keep the nav
+    // open until the user clicked elsewhere.
+    expect(dashboardMenu).toHaveClass('md:nav-auto:has-focus-visible:min-w-56');
+  });
+
+  it('should hold its reveal while a control inside it has a panel open', async () => {
+    const user = userEvent.setup();
+    render(<NavBarNav navMode="auto" />);
+
+    const dashboardMenu = screen.getByRole('navigation', {
+      name: /dashboard navigation menu/i,
+    });
+
+    await user.click(
+      within(dashboardMenu).getByRole('button', {
+        name: /^navigation menu mode:/i,
+      }),
+    );
+
+    // The rule reads the trigger's own `aria-expanded`, so the two halves of
+    // the hold are asserted together: the nav carries the rule, and the
+    // attribute it selects on flips on an element the nav contains. The panel
+    // itself is portaled out and is deliberately not what the rule looks for.
+    expect(dashboardMenu).toHaveClass('md:nav-auto:has-aria-expanded:min-w-56');
+    expect(
+      within(dashboardMenu).getByRole('button', {
+        name: /^navigation menu mode:/i,
+      }),
+    ).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('should not animate under reduced motion', () => {
+    render(<NavBarNav navMode="auto" />);
+
+    const dashboardMenu = screen.getByRole('navigation', {
+      name: /dashboard navigation menu/i,
+    });
+
+    expect(dashboardMenu).toHaveClass('motion-reduce:transition-none');
+  });
+
+  it('should not animate a mode change', () => {
+    render(<NavBarNav navMode="auto" />);
+
+    const dashboardMenu = screen.getByRole('navigation', {
+      name: /dashboard navigation menu/i,
+    });
+
+    // `width` is what a mode sets and `min-width` is what the reveal moves,
+    // so naming the properties is what keeps a mode change instant.
+    expect(dashboardMenu).toHaveClass(
+      'transition-[background-color,border-color,min-width,translate,visibility]',
+    );
   });
 });

--- a/src/module/dashboard/ui/nav-bar/nav/nav.tsx
+++ b/src/module/dashboard/ui/nav-bar/nav/nav.tsx
@@ -42,7 +42,32 @@ export function NavBarNav({
         // initial `min-width` is the keyword `auto`, and a keyword does not
         // interpolate with a length, so leaving it unset makes the reveal jump
         // instead of animating. Both ends of the transition have to be lengths.
-        'border-alpha-grey-300 bg-light-500 dark:bg-dark-500 md:nav-auto:hover:min-w-56 md:nav-expanded:w-56 fixed top-0 left-0 flex h-screen w-56 flex-col border-r pt-16 transition-[background-color,border-color,min-width,translate,visibility] md:visible md:w-16 md:min-w-16 md:translate-x-0',
+        //
+        // Three things hold the reveal open, and all three mean the nav is in
+        // use: a pointer over it, a visible focus inside it, and an open panel
+        // belonging to a control inside it. Focus earns its place on its own,
+        // since the item labels are transparent at the resting width and a
+        // keyboard user would otherwise be reading an unlabelled icon.
+        //
+        // The focus hold reads `:focus-visible` rather than `:focus-within`,
+        // which is what separates a keyboard user from the click that happens
+        // to leave a button focused. On `:focus-within` a pointer user who
+        // picked a mode, or pressed the theme button, would be left with the
+        // nav revealed until they clicked elsewhere. It also puts the reveal on
+        // the same condition as the focus ring, so the nav is open exactly
+        // while an indicator is visible inside it.
+        //
+        // The open panel is read from the trigger's own `aria-expanded` rather
+        // than from a marker the nav sets, so no state has to travel out of the
+        // dropdown. The focus hold cannot stand in for it: the panel is
+        // portaled to `body`, so the nav stops containing focus the moment
+        // focus moves into the panel, and the nav would collapse out from under
+        // an open panel and leave it floating beside a 64px rail.
+        //
+        // `motion-reduce:transition-none` covers the whole list. Everything in
+        // it is the reveal widening or the drawer sliding in, and neither
+        // carries information the user would lose by it being instant.
+        'border-alpha-grey-300 bg-light-500 dark:bg-dark-500 md:nav-auto:hover:min-w-56 md:nav-auto:has-focus-visible:min-w-56 md:nav-auto:has-aria-expanded:min-w-56 md:nav-expanded:w-56 fixed top-0 left-0 flex h-screen w-56 flex-col border-r pt-16 transition-[background-color,border-color,min-width,translate,visibility] motion-reduce:transition-none md:visible md:w-16 md:min-w-16 md:translate-x-0',
         isActive ? 'visible translate-x-0' : 'invisible -translate-x-full',
         className,
       )}

--- a/src/module/dashboard/ui/nav-bar/nav/nav.tsx
+++ b/src/module/dashboard/ui/nav-bar/nav/nav.tsx
@@ -1,5 +1,6 @@
 import { twMerge } from 'tailwind-merge';
 
+import type { NavMode } from '@/dashboard/ui/nav-mode/nav-mode';
 import { CarsIcon } from '@/icons/cars';
 import { HomeIcon } from '@/icons/home';
 import { UserIcon } from '@/icons/user';
@@ -7,8 +8,10 @@ import { ThemeButton } from '@/ui/theme-button/theme-button';
 import { SignOutButton } from '@/user/presentation/ui/buttons/sign-out/sign-out';
 
 import { NavItem } from './item/item';
+import { NavModeDropdown } from './mode-dropdown/mode-dropdown';
 
 type NavBarNavProps = {
+  navMode: NavMode;
   isActive?: boolean;
   onNavigate?: () => void;
   onClose?: () => void;
@@ -17,6 +20,7 @@ type NavBarNavProps = {
 };
 
 export function NavBarNav({
+  navMode,
   onNavigate,
   onClose,
   className,
@@ -55,6 +59,11 @@ export function NavBarNav({
         </NavItem>
       </ul>
       <ul className="before:bg-alpha-grey-300 w-full before:mx-auto before:block before:h-px before:w-3/4">
+        {/* Below `md` the nav is a transient drawer, where a resting width is
+            not a thing the user can have an opinion about. */}
+        <li className="mx-2 my-4 hidden h-12 md:block">
+          <NavModeDropdown className="h-full w-full" navMode={navMode} />
+        </li>
         <li className="mx-2 my-4 h-12">
           <ThemeButton className="h-full w-full" />
         </li>

--- a/src/module/dashboard/ui/nav-bar/nav/nav.tsx
+++ b/src/module/dashboard/ui/nav-bar/nav/nav.tsx
@@ -31,7 +31,18 @@ export function NavBarNav({
     <nav
       aria-label="dashboard navigation menu"
       className={twMerge(
-        'border-alpha-grey-300 bg-light-500 dark:bg-dark-500 fixed top-0 left-0 flex h-screen w-56 flex-col border-r pt-16 transition-all md:visible md:w-16 md:translate-x-0 md:hover:w-56',
+        // The transition names its properties instead of using `all` so that
+        // `width` stays out of it. `width` is the resting width a mode sets,
+        // and a mode change is a decision the user just made rather than
+        // something to watch happen. The transient reveal widens the nav past
+        // that resting width with `min-width`, which is in the list and so
+        // animates.
+        //
+        // `md:min-w-16` restates the resting width and is not redundant: the
+        // initial `min-width` is the keyword `auto`, and a keyword does not
+        // interpolate with a length, so leaving it unset makes the reveal jump
+        // instead of animating. Both ends of the transition have to be lengths.
+        'border-alpha-grey-300 bg-light-500 dark:bg-dark-500 md:nav-auto:hover:min-w-56 md:nav-expanded:w-56 fixed top-0 left-0 flex h-screen w-56 flex-col border-r pt-16 transition-[background-color,border-color,min-width,translate,visibility] md:visible md:w-16 md:min-w-16 md:translate-x-0',
         isActive ? 'visible translate-x-0' : 'invisible -translate-x-full',
         className,
       )}

--- a/src/module/dashboard/ui/nav-bar/use-nav-bar.ts
+++ b/src/module/dashboard/ui/nav-bar/use-nav-bar.ts
@@ -1,0 +1,31 @@
+import { useId, useState } from 'react';
+
+import { useSessionUser } from '@/user/presentation/hook/use-session-user';
+
+export function useDashboardNavBar() {
+  const { data: user, isPending } = useSessionUser();
+
+  // The nav is a drawer below `md` and a permanent rail above it. This state is
+  // the drawer's, and the id is what ties it to the button that opens it.
+  const navId = useId();
+  const [isActive, setIsActive] = useState(false);
+
+  const handleHamburgerButtonClick = () => {
+    setIsActive((currentState) => !currentState);
+  };
+
+  const handleNavClick = () => {
+    if (isActive) {
+      setIsActive(false);
+    }
+  };
+
+  return {
+    user,
+    isPending,
+    navId,
+    isActive,
+    handleHamburgerButtonClick,
+    handleNavClick,
+  };
+}

--- a/src/module/dashboard/ui/nav-mode/nav-mode.test.ts
+++ b/src/module/dashboard/ui/nav-mode/nav-mode.test.ts
@@ -1,0 +1,61 @@
+import {
+  applyNavMode,
+  DEFAULT_NAV_MODE,
+  NAV_MODES,
+  parseNavMode,
+} from './nav-mode';
+
+const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
+
+describe('parseNavMode', () => {
+  it.each(NAV_MODES)('should return %s unchanged', (mode) => {
+    expect(parseNavMode(mode)).toBe(mode);
+  });
+
+  it('should fall back to the default when the cookie is absent', () => {
+    expect(parseNavMode(undefined)).toBe(DEFAULT_NAV_MODE);
+  });
+
+  it('should fall back to the default for an unrecognised value', () => {
+    expect(parseNavMode('sideways')).toBe(DEFAULT_NAV_MODE);
+  });
+
+  it('should fall back to the default for an empty value', () => {
+    expect(parseNavMode('')).toBe(DEFAULT_NAV_MODE);
+  });
+});
+
+describe('applyNavMode', () => {
+  it('should write the mode to the nav-mode cookie', () => {
+    const cookieSpy = jest.spyOn(document, 'cookie', 'set');
+
+    applyNavMode('expanded');
+
+    expect(cookieSpy).toHaveBeenCalledWith(
+      `nav-mode=expanded; Path=/; Max-Age=${ONE_YEAR_IN_SECONDS}; SameSite=Lax`,
+    );
+
+    cookieSpy.mockRestore();
+  });
+
+  it('should set the attribute on the element that carries it', () => {
+    document.body.innerHTML = '<div data-nav-mode="auto"><main></main></div>';
+
+    applyNavMode('collapsed');
+
+    expect(document.querySelector('[data-nav-mode]')).toHaveAttribute(
+      'data-nav-mode',
+      'collapsed',
+    );
+  });
+
+  it('should still write the cookie when no element carries the attribute', () => {
+    const cookieSpy = jest.spyOn(document, 'cookie', 'set');
+    document.body.innerHTML = '<main></main>';
+
+    expect(() => applyNavMode('expanded')).not.toThrow();
+    expect(cookieSpy).toHaveBeenCalled();
+
+    cookieSpy.mockRestore();
+  });
+});

--- a/src/module/dashboard/ui/nav-mode/nav-mode.ts
+++ b/src/module/dashboard/ui/nav-mode/nav-mode.ts
@@ -1,0 +1,45 @@
+/**
+ * How the dashboard nav behaves on wide viewports. Listed in the order the
+ * control offers them: the default first, then by resting width.
+ */
+export const NAV_MODES = ['auto', 'collapsed', 'expanded'] as const;
+
+export type NavMode = (typeof NAV_MODES)[number];
+
+export const DEFAULT_NAV_MODE: NavMode = 'auto';
+
+const NAV_MODE_COOKIE_MAX_AGE_IN_SECONDS = 60 * 60 * 24 * 365;
+
+export const NAV_MODE_COOKIE_NAME = 'nav-mode';
+
+/**
+ * Narrows an untrusted cookie value to a mode.
+ *
+ * The cookie is client-writable and outlives any one build, so a value left by
+ * an older one or by a hand-edited cookie jar has to resolve to something. It
+ * resolves to the mode the dashboard had before the preference existed.
+ */
+export function parseNavMode(value: string | undefined): NavMode {
+  return NAV_MODES.find((mode) => mode === value) ?? DEFAULT_NAV_MODE;
+}
+
+/**
+ * Persists a nav mode and applies it to the page it was chosen on.
+ *
+ * The cookie is what the next request reads, so the first frame the server
+ * sends already carries the right mode and the dashboard never shifts sideways
+ * once JavaScript arrives. The attribute is what the current page responds to,
+ * since all three modes are CSS keyed off it.
+ *
+ * The attribute's element is looked up rather than handed in. It sits on the
+ * dashboard shell, above both the nav and the main region, while the control
+ * that calls this renders inside a panel portaled to `body`, so nothing in the
+ * control's own subtree can reach it.
+ */
+export function applyNavMode(mode: NavMode): void {
+  document.cookie = `${NAV_MODE_COOKIE_NAME}=${mode}; Path=/; Max-Age=${NAV_MODE_COOKIE_MAX_AGE_IN_SECONDS}; SameSite=Lax`;
+
+  document
+    .querySelector('[data-nav-mode]')
+    ?.setAttribute('data-nav-mode', mode);
+}

--- a/test/e2e/nav-mode.ts
+++ b/test/e2e/nav-mode.ts
@@ -1,0 +1,37 @@
+import type { Locator, Page } from '@playwright/test';
+
+/** The nav's resting width above `md`, and the width a reveal takes it to. */
+export const NAV_RAIL_WIDTH = 64;
+export const NAV_REVEALED_WIDTH = 224;
+
+export function navLocator(page: Page): Locator {
+  return page.getByRole('navigation', { name: 'dashboard navigation menu' });
+}
+
+export function navModeTriggerLocator(page: Page): Locator {
+  return page.getByRole('button', { name: /^navigation menu mode:/i });
+}
+
+export async function navWidth(page: Page): Promise<number | undefined> {
+  return (await navLocator(page).boundingBox())?.width;
+}
+
+/**
+ * Picks a mode and leaves the pointer well clear of the nav.
+ *
+ * Picking closes the panel on its own, but the pointer stays where the option
+ * was, and the panel opens from a trigger inside the nav, so that position can
+ * be over the nav itself. The browser re-runs its hit test there once the panel
+ * closes, which in `auto` reveals the nav. Parking the pointer past the nav's
+ * widest is what lets the assertions that follow read a resting width rather
+ * than a revealed one.
+ *
+ * Twice that width is a coordinate every viewport these specs run under can
+ * hold: the narrowest is 1280 across.
+ */
+export async function selectNavMode(page: Page, label: string): Promise<void> {
+  await navModeTriggerLocator(page).click();
+  await page.getByRole('button', { name: label, exact: true }).click();
+
+  await page.mouse.move(NAV_REVEALED_WIDTH * 2, 5);
+}

--- a/test/e2e/nav-mode.ts
+++ b/test/e2e/nav-mode.ts
@@ -12,8 +12,42 @@ export function navModeTriggerLocator(page: Page): Locator {
   return page.getByRole('button', { name: /^navigation menu mode:/i });
 }
 
+/**
+ * The mode control's panel, named by the legend of the fieldset it wraps its
+ * options in.
+ */
+export function navModePanelLocator(page: Page): Locator {
+  return page.getByRole('group', { name: 'Navigation menu mode' });
+}
+
+/**
+ * The panel's positioned container, found through the `aria-controls` the
+ * trigger publishes while the panel is open.
+ *
+ * `navModePanelLocator` lands on the fieldset the options sit in, which is
+ * inset from the container by its border and padding. Anchoring is a property
+ * of the container, since that is the box the dropdown places against the
+ * trigger.
+ *
+ * Matched on the `id` attribute rather than with `#`, because the id comes from
+ * `useId` and carries characters a CSS id selector would have to escape.
+ */
+export async function navModePanelContainerLocator(
+  page: Page,
+): Promise<Locator> {
+  const contentId =
+    await navModeTriggerLocator(page).getAttribute('aria-controls');
+
+  return page.locator(`[id="${contentId}"]`);
+}
+
 export async function navWidth(page: Page): Promise<number | undefined> {
   return (await navLocator(page).boundingBox())?.width;
+}
+
+/** Puts the pointer past the nav's widest, so nothing it does is a hover. */
+export async function parkPointerClearOfNav(page: Page): Promise<void> {
+  await page.mouse.move(NAV_REVEALED_WIDTH * 2, 5);
 }
 
 /**
@@ -33,5 +67,5 @@ export async function selectNavMode(page: Page, label: string): Promise<void> {
   await navModeTriggerLocator(page).click();
   await page.getByRole('button', { name: label, exact: true }).click();
 
-  await page.mouse.move(NAV_REVEALED_WIDTH * 2, 5);
+  await parkPointerClearOfNav(page);
 }

--- a/test/e2e/nav_mode_persistence.test.ts
+++ b/test/e2e/nav_mode_persistence.test.ts
@@ -1,0 +1,76 @@
+import type { Route } from 'next';
+
+import { expect, test } from './fixtures';
+import {
+  NAV_RAIL_WIDTH,
+  NAV_REVEALED_WIDTH,
+  navModeTriggerLocator,
+  navWidth,
+  selectNavMode,
+} from './nav-mode';
+
+const DASHBOARD: Route = '/dashboard';
+
+test.describe('nav_mode_persistence - @desktop @authenticated', () => {
+  test('keeps the chosen mode across a reload - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+
+    await selectNavMode(page, 'Expanded');
+    await page.reload();
+
+    await expect(navModeTriggerLocator(page)).toHaveAccessibleName(
+      'Navigation menu mode: Expanded',
+    );
+    await expect.poll(() => navWidth(page)).toBe(NAV_REVEALED_WIDTH);
+  });
+
+  test('serves the chosen mode in the markup, before hydration - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+
+    await selectNavMode(page, 'Expanded');
+
+    // Read from the response body rather than the DOM: the point is that the
+    // mode is already in the first frame, which a hydrated DOM cannot show.
+    const response = await page.request.get(DASHBOARD);
+
+    expect(await response.text()).toContain('data-nav-mode="expanded"');
+  });
+
+  test('serves auto when no mode has been chosen - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+
+    const response = await page.request.get(DASHBOARD);
+
+    expect(await response.text()).toContain('data-nav-mode="auto"');
+  });
+
+  test('falls back to auto for an unrecognised cookie value - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+
+    await page.context().addCookies([
+      {
+        name: 'nav-mode',
+        value: 'sideways',
+        domain: 'localhost',
+        path: '/',
+      },
+    ]);
+    await page.goto(DASHBOARD);
+
+    const response = await page.request.get(DASHBOARD);
+
+    expect(await response.text()).toContain('data-nav-mode="auto"');
+    await expect(navModeTriggerLocator(page)).toHaveAccessibleName(
+      'Navigation menu mode: Auto',
+    );
+    await expect.poll(() => navWidth(page)).toBe(NAV_RAIL_WIDTH);
+  });
+});

--- a/test/e2e/nav_mode_pointer.test.ts
+++ b/test/e2e/nav_mode_pointer.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from './fixtures';
+import {
+  NAV_RAIL_WIDTH,
+  NAV_REVEALED_WIDTH,
+  navLocator,
+  navWidth,
+  selectNavMode,
+} from './nav-mode';
+
+test.describe('nav_mode_pointer - @desktop @authenticated', () => {
+  test('auto rests narrow, widens under the pointer, and covers nothing - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+    const nav = navLocator(page);
+    const main = page.getByRole('main');
+
+    await expect.poll(() => navWidth(page)).toBe(NAV_RAIL_WIDTH);
+
+    await nav.hover();
+
+    await expect.poll(() => navWidth(page)).toBe(NAV_REVEALED_WIDTH);
+    await expect(nav.getByRole('link', { name: /overview/i })).toBeVisible();
+    // The reveal floats: nothing the user is reading gives up width for it.
+    await expect(main).toHaveCSS('padding-left', `${NAV_RAIL_WIDTH}px`);
+  });
+
+  test('collapsed does not widen under the pointer - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+    const nav = navLocator(page);
+
+    await selectNavMode(page, 'Collapsed');
+
+    await expect.poll(() => navWidth(page)).toBe(NAV_RAIL_WIDTH);
+
+    await nav.hover();
+
+    await expect.poll(() => navWidth(page)).toBe(NAV_RAIL_WIDTH);
+  });
+
+  test('expanded stays wide and the main region gives up the width - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+    const nav = navLocator(page);
+    const main = page.getByRole('main');
+
+    await selectNavMode(page, 'Expanded');
+
+    await expect.poll(() => navWidth(page)).toBe(NAV_REVEALED_WIDTH);
+    await expect(nav.getByRole('link', { name: /overview/i })).toBeVisible();
+    await expect(main).toHaveCSS('padding-left', `${NAV_REVEALED_WIDTH}px`);
+
+    await nav.hover();
+
+    await expect.poll(() => navWidth(page)).toBe(NAV_REVEALED_WIDTH);
+  });
+
+  test('a mode change takes effect without a round trip - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+
+    let navigated = false;
+    page.on('framenavigated', () => {
+      navigated = true;
+    });
+
+    await selectNavMode(page, 'Expanded');
+
+    await expect.poll(() => navWidth(page)).toBe(NAV_REVEALED_WIDTH);
+    expect(navigated).toBe(false);
+  });
+});

--- a/test/e2e/nav_mode_pointer.test.ts
+++ b/test/e2e/nav_mode_pointer.test.ts
@@ -1,11 +1,29 @@
+import type { Page } from '@playwright/test';
+
 import { expect, test } from './fixtures';
 import {
   NAV_RAIL_WIDTH,
   NAV_REVEALED_WIDTH,
   navLocator,
+  navModePanelContainerLocator,
+  navModePanelLocator,
+  navModeTriggerLocator,
   navWidth,
+  parkPointerClearOfNav,
   selectNavMode,
 } from './nav-mode';
+
+/**
+ * Presses Tab once, which lands focus on the first control in the page.
+ *
+ * The focus hold reads `:focus-visible`, and focus moved by script inherits
+ * the visibility of whatever held focus before it. Starting from a real key
+ * press is what makes the `focus()` calls that follow count as a keyboard
+ * user rather than as a click.
+ */
+async function tabIntoThePage(page: Page): Promise<void> {
+  await page.keyboard.press('Tab');
+}
 
 test.describe('nav_mode_pointer - @desktop @authenticated', () => {
   test('auto rests narrow, widens under the pointer, and covers nothing - @desktop', async ({
@@ -72,5 +90,150 @@ test.describe('nav_mode_pointer - @desktop @authenticated', () => {
 
     await expect.poll(() => navWidth(page)).toBe(NAV_REVEALED_WIDTH);
     expect(navigated).toBe(false);
+  });
+
+  test('auto holds its reveal while focus is inside, and the focused item is legible - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+    const nav = navLocator(page);
+
+    await tabIntoThePage(page);
+    await nav.getByRole('link', { name: 'Overview' }).focus();
+
+    await expect.poll(() => navWidth(page)).toBe(NAV_REVEALED_WIDTH);
+    // The reveal is what makes the item readable: at the resting width the
+    // labels are transparent, so focus would land on a bare icon.
+    await expect(nav.getByText('Overview', { exact: true })).toHaveCSS(
+      'opacity',
+      '1',
+    );
+  });
+
+  test('auto collapses once focus leaves - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+    const nav = navLocator(page);
+
+    await tabIntoThePage(page);
+    await nav.getByRole('link', { name: /sign out/i }).focus();
+
+    await expect.poll(() => navWidth(page)).toBe(NAV_REVEALED_WIDTH);
+
+    // Sign out is the nav's last control, so one Tab carries focus out of it.
+    await page.keyboard.press('Tab');
+
+    await expect.poll(() => navWidth(page)).toBe(NAV_RAIL_WIDTH);
+  });
+
+  test('auto holds its reveal while the mode panel is open, and the panel stays anchored - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+    const trigger = navModeTriggerLocator(page);
+    const panel = navModePanelLocator(page);
+
+    await trigger.click();
+    await parkPointerClearOfNav(page);
+
+    await expect(panel).toBeVisible();
+    await expect.poll(() => navWidth(page)).toBe(NAV_REVEALED_WIDTH);
+
+    // The panel is placed once, against the trigger, and follows it only on
+    // scroll and resize. Holding the nav open is what keeps the two together
+    // after the pointer has left.
+    const panelContainer = await navModePanelContainerLocator(page);
+    const panelBox = await panelContainer.boundingBox();
+    const triggerBox = await trigger.boundingBox();
+
+    expect(panelBox?.x).toBeCloseTo(triggerBox?.x ?? 0, 0);
+    expect((panelBox?.y ?? 0) + (panelBox?.height ?? 0)).toBeCloseTo(
+      triggerBox?.y ?? 0,
+      0,
+    );
+  });
+
+  test('auto collapses once the panel is closed and focus leaves - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+    const nav = navLocator(page);
+
+    // Opened from the keyboard, and the pointer never moves, so the reveal
+    // through this journey is the focus hold rather than a hover.
+    await tabIntoThePage(page);
+    await navModeTriggerLocator(page).focus();
+    await page.keyboard.press('Enter');
+    await expect(navModePanelLocator(page)).toBeVisible();
+
+    await page.keyboard.press('Escape');
+
+    // Closing hands focus back to the trigger, which is inside the nav, so the
+    // reveal outlives the panel.
+    await expect(navModePanelLocator(page)).toBeHidden();
+    await expect.poll(() => navWidth(page)).toBe(NAV_REVEALED_WIDTH);
+
+    await nav.getByRole('link', { name: /sign out/i }).focus();
+    await page.keyboard.press('Tab');
+
+    await expect.poll(() => navWidth(page)).toBe(NAV_RAIL_WIDTH);
+  });
+
+  test('auto collapses once a mode has been picked with the pointer - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+
+    // Picking returns focus to the trigger, which is inside the nav. The hold
+    // reads `:focus-visible`, which a click does not set, so the nav has
+    // nothing left to hold it open once the pointer leaves.
+    await selectNavMode(page, 'Auto');
+
+    await expect.poll(() => navWidth(page)).toBe(NAV_RAIL_WIDTH);
+  });
+
+  test('collapsed is revealed by neither focus nor an open panel - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+    const nav = navLocator(page);
+
+    await selectNavMode(page, 'Collapsed');
+
+    await tabIntoThePage(page);
+    await nav.getByRole('link', { name: 'Overview' }).focus();
+
+    await expect.poll(() => navWidth(page)).toBe(NAV_RAIL_WIDTH);
+
+    await navModeTriggerLocator(page).click();
+    await parkPointerClearOfNav(page);
+
+    await expect(navModePanelLocator(page)).toBeVisible();
+    await expect.poll(() => navWidth(page)).toBe(NAV_RAIL_WIDTH);
+  });
+
+  test('the reveal animates and a mode change does not - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+
+    const transitioned = await navLocator(page).evaluate((nav) =>
+      getComputedStyle(nav).transitionProperty.split(', '),
+    );
+
+    // `min-width` is what the reveal moves and `width` is what a mode sets.
+    expect(transitioned).toContain('min-width');
+    expect(transitioned).not.toContain('width');
+  });
+
+  test('the reveal does not animate under reduced motion - @desktop', async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage.page;
+
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+
+    await expect(navLocator(page)).toHaveCSS('transition-property', 'none');
   });
 });


### PR DESCRIPTION
## Summary

- Add a nav mode preference (`auto`, `collapsed`, `expanded`) stored in a cookie and resolved on the server, so the first frame already renders in the chosen mode.
- Add a control in the nav for picking the mode, which applies it to the current page and persists it.
- Hold the nav revealed in `auto` mode while it is in use: a pointer over it, a visible focus inside it, or an open panel belonging to a control inside it.
- Cover the modes and the hold with component and e2e tests.

## Why

The nav rested at 64px and widened on hover, with no way to say "keep it open" or "keep it narrow". The hold also fixes a keyboard gap: item labels are transparent at the resting width, so a keyboard user tabbing through the nav was reading unlabelled icons.

## Key points

- The mode is a data attribute on the dashboard shell, and all three modes are CSS keyed off it. Collapsed needs no rules of its own; it is the resting state everything else already describes.
- The mode is not React state. Applying it writes the cookie and sets the attribute directly; the dropdown's local state exists only to mark the checked option and name the trigger.
- A mode change is instant and only the transient reveal animates, which is why the resting width and the reveal use different properties.
- The reveal holds on conditions that mean the nav is genuinely in use, so a click that happens to leave a button focused does not pin it open, and an open panel keeps it open even though the panel renders outside the nav.