### PR TITLE
fix(ownership): remove the flicker when adding an owner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "react-hook-form": "7.85.0",
+        "sharp": "0.35.3",
         "tailwind-merge": "3.6.0",
         "zod": "4.4.3"
       },
@@ -1700,7 +1701,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -6615,7 +6615,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -12687,7 +12686,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -12750,7 +12748,6 @@
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
       "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-hook-form": "7.85.0",
+    "sharp": "0.35.3",
     "tailwind-merge": "3.6.0",
     "zod": "4.4.3"
   },

--- a/src/module/car/ownership/presentation/hook/use-owner-profiles-for-car.test.tsx
+++ b/src/module/car/ownership/presentation/hook/use-owner-profiles-for-car.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 
 import { buildOwnershipDto } from '@/car/ownership/application/dto/ownership.builder';
@@ -42,7 +42,7 @@ function createWrapper() {
     );
   }
 
-  return Wrapper;
+  return { Wrapper, queryClient };
 }
 
 beforeEach(() => {
@@ -58,7 +58,7 @@ beforeEach(() => {
 describe('useOwnerProfilesForCar', () => {
   it('returns ownerships and owner profiles after a successful fetch', async () => {
     const { result } = renderHook(() => useOwnerProfilesForCar('car-1'), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper().Wrapper,
     });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -69,7 +69,7 @@ describe('useOwnerProfilesForCar', () => {
 
   it('fetches each owner profile by its owner id', async () => {
     renderHook(() => useOwnerProfilesForCar('car-1'), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper().Wrapper,
     });
 
     await waitFor(() =>
@@ -84,7 +84,7 @@ describe('useOwnerProfilesForCar', () => {
     mockOwnershipDataSource.getByCarId.mockResolvedValue(Result.ok([]));
 
     const { result } = renderHook(() => useOwnerProfilesForCar('car-1'), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper().Wrapper,
     });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -98,7 +98,7 @@ describe('useOwnerProfilesForCar', () => {
     );
 
     renderHook(() => useOwnerProfilesForCar('car-1'), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper().Wrapper,
     });
 
     await waitFor(() =>
@@ -110,13 +110,56 @@ describe('useOwnerProfilesForCar', () => {
     );
   });
 
+  it('keeps loaded owner profiles on screen while a newly added owner is fetched', async () => {
+    const { Wrapper, queryClient } = createWrapper();
+    const addedOwnership = buildOwnershipDto({ ownerId: 'owner-3' });
+    const addedUser = buildUserDto({ id: 'owner-3' });
+    const { result } = renderHook(() => useOwnerProfilesForCar('car-1'), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let resolveAddedUser: () => void = () => {};
+    mockUserDataSource.getById.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        resolveAddedUser = resolve;
+      });
+      return Result.ok(addedUser);
+    });
+
+    act(() => {
+      queryClient.setQueryData(queryKeys.byCarId('car-1'), [
+        ...MOCK_OWNERSHIPS,
+        addedOwnership,
+      ]);
+    });
+
+    await waitFor(() =>
+      expect(mockUserDataSource.getById).toHaveBeenCalledWith('owner-3'),
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.users).toEqual([MOCK_USER_1, MOCK_USER_2]);
+
+    act(() => resolveAddedUser());
+
+    await waitFor(() =>
+      expect(result.current.users).toEqual([
+        MOCK_USER_1,
+        MOCK_USER_2,
+        addedUser,
+      ]),
+    );
+  });
+
   it('shows a single combined error toast when owner-profile fetches fail', async () => {
     mockUserDataSource.getById.mockResolvedValue(
       Result.fail({ message: 'User error' }),
     );
 
     renderHook(() => useOwnerProfilesForCar('car-1'), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper().Wrapper,
     });
 
     await waitFor(() =>

--- a/src/module/car/ownership/presentation/hook/use-owner-profiles-for-car.ts
+++ b/src/module/car/ownership/presentation/hook/use-owner-profiles-for-car.ts
@@ -26,7 +26,10 @@ export function useOwnerProfilesForCar(carId: string) {
     queries: ownerIds.map((ownerId) => getUserByIdQueryOptions(ownerId)),
     combine: (results) => ({
       users: results.flatMap((result) => (result.data ? [result.data] : [])),
-      isLoading: results.some((result) => result.isLoading),
+      //! `every`, not `some`: adding an owner mounts one more profile query,
+      //! and a pending newcomer must not blank the profiles already on screen.
+      isLoading:
+        results.length > 0 && results.every((result) => result.isLoading),
       failedCount: results.filter((result) => result.isError).length,
     }),
   });

--- a/src/module/car/ownership/presentation/tanstack/mutation/add.test.tsx
+++ b/src/module/car/ownership/presentation/tanstack/mutation/add.test.tsx
@@ -6,6 +6,7 @@ import {
 import { renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 
+import type { OwnershipDto } from '@/car/ownership/application/dto/ownership';
 import { buildOwnershipDto } from '@/car/ownership/application/dto/ownership.builder';
 import { ownershipApiClient } from '@/car/ownership/dependency/api-client';
 import { ownershipAddMutationOptions } from '@/car/ownership/presentation/tanstack/mutation/add';
@@ -62,10 +63,47 @@ describe('ownershipAddMutationOptions', () => {
           carId: 'car-1',
           ownerId: 'owner-2',
           isPrimary: false,
-          createdAt: null,
+          createdAt: expect.any(String),
         },
       ]);
     });
+  });
+
+  it('stamps the optimistic ownership so it already sorts as the newest row', async () => {
+    const existingCreatedAt = '2024-01-01T00:00:00';
+    const existingOwnership = buildOwnershipDto({
+      carId: 'car-1',
+      createdAt: existingCreatedAt,
+    });
+
+    mockOwnershipApiClient.add.mockReturnValue(new Promise(() => {}));
+
+    const wrapper = createWrapper();
+    queryClient.setQueryData(queryKeys.byCarId('car-1'), [existingOwnership]);
+
+    const { result } = renderHook(
+      () => useMutation(ownershipAddMutationOptions),
+      { wrapper },
+    );
+
+    result.current.mutate({ carId: 'car-1', ownerId: 'owner-2' });
+
+    let addedCreatedAt = '';
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<OwnershipDto[]>(
+        queryKeys.byCarId('car-1'),
+      );
+
+      expect(data).toHaveLength(2);
+
+      addedCreatedAt = data?.[1].createdAt ?? '';
+    });
+
+    expect(addedCreatedAt > existingCreatedAt).toBe(true);
+    // Server rows carry a zone-less timestamp; the optimistic one has to sort
+    // against them under the same shape.
+    expect(addedCreatedAt).not.toMatch(/Z$/);
   });
 
   it('rolls back the cached list when the add fails', async () => {

--- a/src/module/car/ownership/presentation/tanstack/mutation/add.ts
+++ b/src/module/car/ownership/presentation/tanstack/mutation/add.ts
@@ -32,12 +32,18 @@ export const ownershipAddMutationOptions = mutationOptions({
       queryKeys.byCarId(carId),
     );
 
+    //! The table sorts on `createdAt`, so `null` would park the new row at the
+    //! bottom and let the refetch visibly jump it to the top. Postgres stores
+    //! the column zone-less, hence trimming the `Z`: the optimistic value has
+    //! to sort against server rows under the same string shape.
+    const createdAt = new Date().toISOString().slice(0, -1);
+
     context.client.setQueryData(
       queryKeys.byCarId(carId),
       (current: OwnershipDto[] | undefined) =>
         current && [
           ...current,
-          { carId, ownerId, isPrimary: false, createdAt: null },
+          { carId, ownerId, isPrimary: false, createdAt },
         ],
     );
 

--- a/src/module/car/presentation/ui/form/fields/fields.tsx
+++ b/src/module/car/presentation/ui/form/fields/fields.tsx
@@ -66,6 +66,7 @@ export function FormFields({
     <>
       <Form.InputWrapper className="md:justify-center">
         <Form.InputImage
+          className="mx-auto max-w-72"
           control={control}
           errorMessage={errors.image?.message}
           label="Image"
@@ -144,7 +145,7 @@ export function FormFields({
         />
       </Form.InputWrapper>
       <Form.InputWrapper>
-        <div className="bg-alpha-grey-300 mb-4 h-px w-full md:block lg:hidden" />
+        <div className="bg-alpha-grey-300 mb-4 h-px w-full md:hidden" />
         <Form.Input
           errorMessage={errors.engineCapacity?.message}
           label="Engine Capacity [cc]"
@@ -187,7 +188,7 @@ export function FormFields({
       </Form.InputWrapper>
 
       <Form.InputWrapper>
-        <div className="bg-alpha-grey-300 mb-4 h-px w-full md:block lg:hidden" />
+        <div className="bg-alpha-grey-300 mb-4 h-px w-full md:hidden" />
         <Form.Input
           errorMessage={errors.mileage?.message}
           label="Mileage [km]"

--- a/src/module/user/presentation/ui/id-clipboard-button/id-clipboard-button.tsx
+++ b/src/module/user/presentation/ui/id-clipboard-button/id-clipboard-button.tsx
@@ -48,8 +48,7 @@ export function IdClipboardButton({
         aria-label={copied ? 'ID copied' : 'Copy ID'}
         className={twMerge(
           inputVariants[variant],
-          'my-1 flex items-center gap-2 p-0',
-          'hover:border-accent-500 transition-colors',
+          'hover:border-accent-500 my-1 flex items-center gap-2 p-0 transition-colors hover:cursor-pointer',
           className,
         )}
         title={copied ? 'ID copied' : 'Copy ID'}


### PR DESCRIPTION
## Summary

- The ownerships section keeps its table on screen while a newly added owner's
  profile loads, instead of collapsing back to the spinner.
- A newly added owner sorts as the newest row straight away instead of sitting
  at the bottom until the refetch moves it.
- `CarForm` caps the image field width, and the separator above Engine Capacity
  and Mileage now hides from `md` up.
- `IdClipboardButton` shows a pointer cursor on hover.
- Adds `sharp` as a dependency.

## Why

Adding an owner produced two visible jumps: the table collapsed to a spinner,
then the new row moved from the bottom to the top once the refetch landed.

## Key points

- The section's spinner means "nothing to show yet". A query mounting for newly
  added data must not blank rows already rendered.
- The table sorts `createdAt` as text against zone-less Postgres timestamps, so
  the optimistic row has to carry a timestamp in that same shape.